### PR TITLE
fix(scripts): correctly build standalone libraries

### DIFF
--- a/packages/scripts/scripts/utils/configs.js
+++ b/packages/scripts/scripts/utils/configs.js
@@ -59,7 +59,7 @@ function configCheck() {
     console.log(chalk.green(`${icons.check} Configs match up`));
   } else {
     console.log(
-      chalk.yellow(`${icons.warning} There is no configs for this project`)
+      chalk.yellow(`${icons.warning} There are no configs for this project`)
     );
   }
 }


### PR DESCRIPTION
Standalon lib broke if storybook/cypress was included. This correctly sets up typescript for when there are multilple "roots" apart from src and only src folder.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/scripts@1.1.4-canary.14.50473522e39f23b3cf9f581567f5b5e9181b90ae.0
  # or 
  yarn add @tablecheck/scripts@1.1.4-canary.14.50473522e39f23b3cf9f581567f5b5e9181b90ae.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
