### PR TITLE
fix(scripts): correctly init tsconfig for cypress in lib projects

### DIFF
--- a/packages/scripts/scripts/utils/configureTypescript.js
+++ b/packages/scripts/scripts/utils/configureTypescript.js
@@ -149,6 +149,23 @@ module.exports = {
     }
     if (fs.existsSync(paths.cypress)) {
       eslintRoots.push('cypress');
+      writeTsConfig(
+        path.join(paths.cypress, 'tsconfig.json'),
+        {
+          ...packageConfig,
+          extends: '@tablecheck/scripts/tsconfig/base.json',
+          include: ['**/*.ts'],
+          compilerOptions: {
+            baseUrl: path.relative(paths.cypress, path.join(paths.cwd, 'src')),
+            lib: ['dom', 'dom.iterable', 'esnext'],
+            module: 'esnext',
+            target: 'es5',
+            noEmit: true,
+            isolatedModules: false
+          }
+        },
+        true
+      );
     }
     if (lernaPaths.length) {
       lernaPaths.forEach((localPath) => {

--- a/packages/scripts/scripts/utils/validateEslintrc.js
+++ b/packages/scripts/scripts/utils/validateEslintrc.js
@@ -40,7 +40,7 @@ module.exports = function validateEslintrc() {
         )
       );
       fs.copyFileSync(
-        require.resolve(`../templates/${eslintRcFile}`),
+        require.resolve(`../../templates/${eslintRcFile}`),
         eslintRcPath
       );
     }


### PR DESCRIPTION
Fixing an issue where the lib version of config typescript was missing some parts used in the app configure so the config didn't work.
Also fix the file path for the reset in validate eslintrc.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/scripts@1.1.5-canary.17.41f64a1abe85c45cf2f752a99d36520b524ff6cf.0
  # or 
  yarn add @tablecheck/scripts@1.1.5-canary.17.41f64a1abe85c45cf2f752a99d36520b524ff6cf.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
