### PR TITLE
feat(scripts): cypress component testing + razzle config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,5 +6,6 @@ node_modules
 packages/scripts/tsconfig/definitions.d.ts
 packages/scripts/tsconfig/defaultDefinitions.d.ts
 packages/scripts/scripts/rollup/fixtures/*
+packages/scripts/cypressComponentTesting.d.ts
 packages/scripts/templates/*
 packages/codemods/testFiles/*

--- a/auditjs.json
+++ b/auditjs.json
@@ -23,6 +23,9 @@
     },
     {
       "id": "7b682dd5-ef07-459c-be11-50ec76c9eba2"
+    },
+    {
+      "id": "64cd5f21-8af4-4eae-ac7d-a53241ea693a"
     }
   ],
   "affected": [
@@ -171,6 +174,36 @@
           "cvssVector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
           "cve": "CVE-2021-32640",
           "reference": "https://ossindex.sonatype.org/vulnerability/7b682dd5-ef07-459c-be11-50ec76c9eba2?component-type=npm&component-name=ws&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/glob-parent@2.0.0",
+      "description": "Extract the non-magic parent path from a glob string.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/glob-parent@2.0.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.28",
+      "vulnerabilities": [
+        {
+          "id": "64cd5f21-8af4-4eae-ac7d-a53241ea693a",
+          "title": "CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')",
+          "description": "The software does not properly restrict the size or amount of resources that are requested or influenced by an actor, which can be used to consume more resources than intended.",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "reference": "https://ossindex.sonatype.org/vulnerability/64cd5f21-8af4-4eae-ac7d-a53241ea693a?component-type=npm&component-name=glob-parent&utm_source=auditjs&utm_medium=integration&utm_content=4.0.28"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/glob-parent@3.1.0",
+      "description": "Extract the non-magic parent path from a glob string.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/glob-parent@3.1.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.28",
+      "vulnerabilities": [
+        {
+          "id": "64cd5f21-8af4-4eae-ac7d-a53241ea693a",
+          "title": "CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')",
+          "description": "The software does not properly restrict the size or amount of resources that are requested or influenced by an actor, which can be used to consume more resources than intended.",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "reference": "https://ossindex.sonatype.org/vulnerability/64cd5f21-8af4-4eae-ac7d-a53241ea693a?component-type=npm&component-name=glob-parent&utm_source=auditjs&utm_medium=integration&utm_content=4.0.28"
         }
       ]
     }

--- a/packages/eslint-config/overrides/cypress.js
+++ b/packages/eslint-config/overrides/cypress.js
@@ -16,7 +16,7 @@ const jestOverrides = Object.keys(jestPlugin.configs.all.rules).reduce(
 );
 
 module.exports = merge(require('./typescript'), {
-  files: ['**/cypress/**/*'],
+  files: ['**/cypress/**/*', '**/*.cypress.ts', '**/*.cypress.tsx'],
   parserOptions: {
     ecmaVersion: 9,
     sourceType: 'module',
@@ -31,6 +31,7 @@ module.exports = merge(require('./typescript'), {
     'promise/catch-or-return': 'off',
     'promise/always-return': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-namespace': 'off',
     '@typescript-eslint/naming-convention': [].concat(
       namingConfig['@typescript-eslint/naming-convention'],
       [

--- a/packages/scripts/cypressComponentTesting.d.ts
+++ b/packages/scripts/cypressComponentTesting.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="cypress" />
+export const cypressComponentTesting: Cypress.PluginConfig;

--- a/packages/scripts/cypressComponentTesting.js
+++ b/packages/scripts/cypressComponentTesting.js
@@ -1,0 +1,53 @@
+const path = require('path');
+
+// eslint-disable-next-line import/no-unresolved
+const { startDevServer } = require('@cypress/webpack-dev-server');
+
+const setPorts = require('razzle-dev-utils/setPorts');
+const createConfigAsync = require('razzle/config/createConfigAsync');
+const loadRazzleConfig = require('razzle/config/loadRazzleConfig');
+const webpack = require('webpack');
+
+async function cypressComponentTesting(on, config) {
+  // `on` is used to hook into various events Cypress emits
+  // `config` is the resolved Cypress config
+  if (config.testingType === 'component') {
+    on('dev-server:start', async (options) => {
+      const { razzle, razzleOptions, webpackObject, plugins, paths } =
+        await loadRazzleConfig(webpack);
+      if (!razzleOptions.verbose) {
+        process.removeAllListeners('warning');
+      }
+      const isClientOnly = true;
+      await setPorts(isClientOnly);
+      const webpackConfig = await createConfigAsync(
+        'web',
+        'dev',
+        razzle,
+        webpackObject,
+        isClientOnly,
+        paths,
+        plugins,
+        {
+          ...razzleOptions,
+          enableReactRefresh: false
+        }
+      );
+      webpackConfig.module.rules[0].include.push(
+        path.join(paths.appSrc, '../cypress')
+      );
+      webpackConfig.output.libraryTarget = undefined;
+      webpackConfig.output.library = undefined;
+      webpackConfig.devServer = undefined;
+      webpackConfig.entry.client.splice(1, 1);
+      return startDevServer({
+        options,
+        webpackConfig
+      });
+    });
+    config.env.reactDevtools = true;
+  }
+  return config;
+}
+
+module.exports = { cypressComponentTesting };

--- a/packages/scripts/cypressComponentTesting.stories.mdx
+++ b/packages/scripts/cypressComponentTesting.stories.mdx
@@ -1,0 +1,23 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="scripts/Cypress Component Testing" />
+
+## Cypress Component Testing
+
+To get our system setup with [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/introduction) follow the following steps.
+
+1. Ensure Cypress >= 8 is installed.
+2. Use the init script to copy over the template files and update your package.json (use the cypress option).
+3. Install `@cypress/webpack-dev-server` and `@cypress/react` as dev dependencies.
+4. Add the following to `cypress/plugins/index.ts`
+
+```ts
+import { cypressComponentTesting } from '@tablecheck/scripts/cypressComponentTesting';
+
+/**
+ * @type {Cypress.PluginConfig}
+ */
+module.exports = ((on, config) => {
+  return cypressComponentTesting(on, config);
+}) as Cypress.PluginConfig;
+```

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -12,6 +12,8 @@
   "files": [
     "bin",
     "config",
+    "cypressComponentTesting.d.ts",
+    "cypressComponentTesting.js",
     "razzle",
     "scripts",
     "templates",

--- a/packages/scripts/razzle/sspa.js
+++ b/packages/scripts/razzle/sspa.js
@@ -1,5 +1,6 @@
 const { produce } = require('immer');
 const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
+const config = require('config');
 const baseConfig = require('./spa');
 const paths = require('../config/paths');
 const { getArgv } = require('../scripts/utils/argv');
@@ -26,7 +27,15 @@ module.exports = baseConfig.extend({
         webpackConfigDraft.output.library = appPackage.name;
         webpackConfigDraft.output.libraryTarget = 'amd';
       }
-      webpackConfigDraft.plugins.push(new WebpackManifestPlugin());
+      webpackConfigDraft.plugins.push(
+        new WebpackManifestPlugin({
+          seed: {
+            // seed the manifest with the appVersion so that the parent app can report
+            // the version of each child app
+            appVersion: config.appVersion
+          }
+        })
+      );
     })(webpackConfig);
   }
 });

--- a/packages/scripts/scripts/init.js
+++ b/packages/scripts/scripts/init.js
@@ -106,7 +106,9 @@ const promptChoices = [
 const cypressScripts = {
   'build:test': 'PORT=8089 NODE_CONFIG_ENV=test razzle build --standalone',
   'cypress:open': 'cypress open',
+  'cypress:open-component': 'cypress open-ct',
   'cypress:run': 'cypress run',
+  'cypress:run-component': 'cypress run-ct',
   'start:build':
     'http-server ./build/public -p 8089 --proxy http://localhost:8089? --silent',
   'start:test': 'PORT=8089 NODE_CONFIG_ENV=test razzle start --standalone',
@@ -117,7 +119,7 @@ const cypressScripts = {
   'test:integration:dev':
     'start-server-and-test start:test http://localhost:8089/ cypress:open'
 };
-const cypressDevDependencies = ['cypress@^6.4.0', '@types/cypress@^1.1.3'];
+const cypressDevDependencies = ['cypress@^8.3.0'];
 
 const storybookScripts = {
   'build:storybook': 'build-storybook -o docs',

--- a/packages/scripts/templates/cypress.json
+++ b/packages/scripts/templates/cypress.json
@@ -1,8 +1,13 @@
 {
   "baseUrl": "http://localhost:3000",
   "env": {},
+  "testFiles": "**/*.spec.ts",
   "reporter": "junit",
   "reporterOptions": {
     "mochaFile": "junit/cypress-[hash].xml"
+  },
+  "component": {
+    "testFiles": "**/*.cypress.{ts,tsx}",
+    "componentFolder": "src"
   }
 }


### PR DESCRIPTION
Update razzle sspa config to inject the app version into manifest automaticaly.
Add shared cypress component testing configuration utils and fixing some eslint rules for cypress.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/eslint-config@1.2.0-canary.18.4e7d008cbb4e314d16bcce66958948b9156cc753.0
  npm install @tablecheck/scripts@1.2.0-canary.18.4e7d008cbb4e314d16bcce66958948b9156cc753.0
  # or 
  yarn add @tablecheck/eslint-config@1.2.0-canary.18.4e7d008cbb4e314d16bcce66958948b9156cc753.0
  yarn add @tablecheck/scripts@1.2.0-canary.18.4e7d008cbb4e314d16bcce66958948b9156cc753.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
