### PR TITLE
fix: release process

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -13,7 +13,6 @@
         }
       }
     ],
-    "conventional-commits",
     "first-time-contributor",
     "released",
     [

--- a/.github/workflows/label_checker.yml
+++ b/.github/workflows/label_checker.yml
@@ -23,6 +23,6 @@ jobs:
     steps:
       - uses: agilepathway/label-checker@v1.0.91
         with:
-          one_of: major,minor,patch,internal
+          one_of: major,minor,patch,skip-release,internal,documentation,tests,dependencies,performance
           none_of: invalid,wontfix,duplicate,question
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: Auto Release
 
 on:
-  workflow_dispatch:
-    # this allows us to manually run the release on other branches for canary and pre-releases
   push:
     branches:
       - main
@@ -14,8 +12,13 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+
+      - name: Prepare repository
+        run: git fetch --unshallow --prune --tags
+
+      - name: Unset header
+        # checkout@v2 adds a header that makes branch protection report errors ):
+        run: git config --local --unset http.https://github.com/.extraheader
 
       - name: Read .nvmrc
         id: nvm
@@ -35,7 +38,7 @@ jobs:
 
       - name: Create Release ✨
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SIMEON_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
         run: npx auto shipit

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,7 +105,6 @@
 			},
 			"devDependencies": {
 				"@auto-it/all-contributors": "10.30.0",
-				"@auto-it/conventional-commits": "10.30.0",
 				"@auto-it/first-time-contributor": "10.30.0",
 				"@auto-it/npm": "10.30.0",
 				"@auto-it/released": "10.30.0",
@@ -183,23 +182,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=10.x"
-			}
-		},
-		"node_modules/@auto-it/conventional-commits": {
-			"version": "10.30.0",
-			"resolved": "https://registry.npmjs.org/@auto-it/conventional-commits/-/conventional-commits-10.30.0.tgz",
-			"integrity": "sha512-K8EN+aaoMsfklTEqvDkfFmwPUSGDh5PhkqrM6w7d6VIvgHRBIWWXY95w3MrATxpFFqunwiCOaIPWGChuJ3tLFg==",
-			"dev": true,
-			"dependencies": {
-				"@auto-it/core": "10.30.0",
-				"array.prototype.flatmap": "^1.2.2",
-				"conventional-changelog-core": "^4.2.0",
-				"conventional-changelog-preset-loader": "^2.3.4",
-				"conventional-commits-parser": "^3.1.0",
-				"endent": "^2.0.1",
-				"fp-ts": "^2.5.3",
-				"io-ts": "^2.1.2",
-				"tslib": "2.1.0"
 			}
 		},
 		"node_modules/@auto-it/core": {
@@ -2774,7 +2756,7 @@
 		},
 		"node_modules/@emotion/styled": {
 			"version": "11.3.0",
-			"resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.3.0.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/@emotion/styled/-/styled-11.3.0.tgz",
 			"integrity": "sha512-fUoLcN3BfMiLlRhJ8CuPUMEyKkLEoM+n+UyAbnqGEsCd5IzKQ7VQFLtzpJOaCD2/VR2+1hXQTnSZXVJeiTNltA==",
 			"dependencies": {
 				"@babel/runtime": "^7.13.10",
@@ -2787,14 +2769,6 @@
 				"@babel/core": "^7.0.0",
 				"@emotion/react": "^11.0.0-rc.0",
 				"react": ">=16.8.0"
-			},
-			"peerDependenciesMeta": {
-				"@babel/core": {
-					"optional": true
-				},
-				"@types/react": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@emotion/styled-base": {
@@ -2815,7 +2789,7 @@
 		},
 		"node_modules/@emotion/styled/node_modules/@emotion/is-prop-valid": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.1.0.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/@emotion/is-prop-valid/-/is-prop-valid-1.1.0.tgz",
 			"integrity": "sha512-9RkilvXAufQHsSsjQ3PIzSns+pxuX4EW8EbGeSPjZMHuMx6z/MOzb9LpqNieQX4F3mre3NWS2+X3JNRHTQztUQ==",
 			"dependencies": {
 				"@emotion/memoize": "^0.7.4"
@@ -2823,7 +2797,7 @@
 		},
 		"node_modules/@emotion/styled/node_modules/@emotion/serialize": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/@emotion/serialize/-/serialize-1.0.2.tgz",
 			"integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
 			"dependencies": {
 				"@emotion/hash": "^0.8.0",
@@ -2835,12 +2809,12 @@
 		},
 		"node_modules/@emotion/styled/node_modules/@emotion/utils": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/@emotion/utils/-/utils-1.0.0.tgz",
 			"integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
 		},
 		"node_modules/@emotion/styled/node_modules/csstype": {
 			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/csstype/-/csstype-3.0.8.tgz",
 			"integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
 		},
 		"node_modules/@emotion/stylis": {
@@ -20404,12 +20378,8 @@
 		},
 		"node_modules/immer": {
 			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/immer/-/immer-9.0.5.tgz",
-			"integrity": "sha512-2WuIehr2y4lmYz9gaQzetPR2ECniCifk4ORaQbU3g5EalLt+0IVTosEPJ5BoYl/75ky2mivzdRzV8wWgQGOSYQ==",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/immer"
-			}
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/immer/-/immer-9.0.5.tgz",
+			"integrity": "sha512-2WuIehr2y4lmYz9gaQzetPR2ECniCifk4ORaQbU3g5EalLt+0IVTosEPJ5BoYl/75ky2mivzdRzV8wWgQGOSYQ=="
 		},
 		"node_modules/import-cwd": {
 			"version": "3.0.0",
@@ -20613,7 +20583,7 @@
 		},
 		"node_modules/inquirer": {
 			"version": "8.1.2",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.1.2.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/inquirer/-/inquirer-8.1.2.tgz",
 			"integrity": "sha512-DHLKJwLPNgkfwNmsuEUKSejJFbkv0FMO9SMiQbjI3n5NQuCrSIBqP66ggqyz2a6t2qEolKrMjhQ3+W/xXgUQ+Q==",
 			"dependencies": {
 				"ansi-escapes": "^4.2.1",
@@ -20637,7 +20607,7 @@
 		},
 		"node_modules/inquirer/node_modules/ora": {
 			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/ora/-/ora-5.4.1.tgz",
 			"integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
 			"dependencies": {
 				"bl": "^4.1.0",
@@ -20652,14 +20622,11 @@
 			},
 			"engines": {
 				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/inquirer/node_modules/rxjs": {
 			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.3.0.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/rxjs/-/rxjs-7.3.0.tgz",
 			"integrity": "sha512-p2yuGIg9S1epc3vrjKf6iVb3RCaAYjYskkO+jHIaV0IjOPlJop4UnodOoFb2xeNwlguqLYvGw1b1McillYb5Gw==",
 			"dependencies": {
 				"tslib": "~2.1.0"
@@ -24094,7 +24061,7 @@
 		},
 		"node_modules/jscodeshift": {
 			"version": "0.13.0",
-			"resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.13.0.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/jscodeshift/-/jscodeshift-0.13.0.tgz",
 			"integrity": "sha512-FNHLuwh7TeI0F4EzNVIRwUSxSqsGWM5nTv596FK4NfBnEEKFpIcyFeG559DMFGHSTIYA5AY4Fqh2cBrJx0EAwg==",
 			"dependencies": {
 				"@babel/core": "^7.13.16",
@@ -24126,7 +24093,7 @@
 		},
 		"node_modules/jscodeshift/node_modules/braces": {
 			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/braces/-/braces-2.3.2.tgz",
 			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 			"dependencies": {
 				"arr-flatten": "^1.1.0",
@@ -24146,7 +24113,7 @@
 		},
 		"node_modules/jscodeshift/node_modules/braces/node_modules/extend-shallow": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/extend-shallow/-/extend-shallow-2.0.1.tgz",
 			"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 			"dependencies": {
 				"is-extendable": "^0.1.0"
@@ -24157,7 +24124,7 @@
 		},
 		"node_modules/jscodeshift/node_modules/fill-range": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/fill-range/-/fill-range-4.0.0.tgz",
 			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 			"dependencies": {
 				"extend-shallow": "^2.0.1",
@@ -24171,7 +24138,7 @@
 		},
 		"node_modules/jscodeshift/node_modules/fill-range/node_modules/extend-shallow": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/extend-shallow/-/extend-shallow-2.0.1.tgz",
 			"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 			"dependencies": {
 				"is-extendable": "^0.1.0"
@@ -24182,12 +24149,12 @@
 		},
 		"node_modules/jscodeshift/node_modules/is-buffer": {
 			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/is-buffer/-/is-buffer-1.1.6.tgz",
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
 		"node_modules/jscodeshift/node_modules/is-extendable": {
 			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/is-extendable/-/is-extendable-0.1.1.tgz",
 			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
 			"engines": {
 				"node": ">=0.10.0"
@@ -24195,7 +24162,7 @@
 		},
 		"node_modules/jscodeshift/node_modules/is-number": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/is-number/-/is-number-3.0.0.tgz",
 			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 			"dependencies": {
 				"kind-of": "^3.0.2"
@@ -24206,7 +24173,7 @@
 		},
 		"node_modules/jscodeshift/node_modules/is-number/node_modules/kind-of": {
 			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 			"dependencies": {
 				"is-buffer": "^1.1.5"
@@ -24217,7 +24184,7 @@
 		},
 		"node_modules/jscodeshift/node_modules/isobject": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/isobject/-/isobject-3.0.1.tgz",
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"engines": {
 				"node": ">=0.10.0"
@@ -24225,7 +24192,7 @@
 		},
 		"node_modules/jscodeshift/node_modules/micromatch": {
 			"version": "3.1.10",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/micromatch/-/micromatch-3.1.10.tgz",
 			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 			"dependencies": {
 				"arr-diff": "^4.0.0",
@@ -24248,7 +24215,7 @@
 		},
 		"node_modules/jscodeshift/node_modules/recast": {
 			"version": "0.20.5",
-			"resolved": "https://registry.npmjs.org/recast/-/recast-0.20.5.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/recast/-/recast-0.20.5.tgz",
 			"integrity": "sha512-E5qICoPoNL4yU0H0NoBDntNB0Q5oMSNh9usFctYniLBluTthi3RsQVBXIJNbApOlvSwW/RGxIuokPcAc59J5fQ==",
 			"dependencies": {
 				"ast-types": "0.14.2",
@@ -24262,7 +24229,7 @@
 		},
 		"node_modules/jscodeshift/node_modules/source-map": {
 			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"engines": {
 				"node": ">=0.10.0"
@@ -24270,7 +24237,7 @@
 		},
 		"node_modules/jscodeshift/node_modules/to-regex-range": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/to-regex-range/-/to-regex-range-2.1.1.tgz",
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 			"dependencies": {
 				"is-number": "^3.0.0",
@@ -24282,7 +24249,7 @@
 		},
 		"node_modules/jscodeshift/node_modules/write-file-atomic": {
 			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
 			"integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
 			"dependencies": {
 				"graceful-fs": "^4.1.11",
@@ -39286,7 +39253,7 @@
 		},
 		"node_modules/webpack-manifest-plugin": {
 			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-4.0.2.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/webpack-manifest-plugin/-/webpack-manifest-plugin-4.0.2.tgz",
 			"integrity": "sha512-Ld6j05pRblXAVoX8xdXFDsc/s97cFnR1FOmQawhTSlp6F6aeU1Jia5aqTmDpkueaAz8g9sXpgSOqmEgVAR61Xw==",
 			"dependencies": {
 				"tapable": "^2.0.0",
@@ -39301,7 +39268,7 @@
 		},
 		"node_modules/webpack-manifest-plugin/node_modules/source-map": {
 			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"engines": {
 				"node": ">=0.10.0"
@@ -39309,7 +39276,7 @@
 		},
 		"node_modules/webpack-manifest-plugin/node_modules/webpack-sources": {
 			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.3.1.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/webpack-sources/-/webpack-sources-2.3.1.tgz",
 			"integrity": "sha512-y9EI9AO42JjEcrTJFOYmVywVZdKVUfOvDUPsJea5GIr1JOEGFVqwlY2K098fFoIjOkDzHn2AjRvM8dsBZu+gCA==",
 			"dependencies": {
 				"source-list-map": "^2.0.1",
@@ -40315,7 +40282,7 @@
 		},
 		"packages/babel-preset": {
 			"name": "@tablecheck/babel-preset",
-			"version": "1.0.1",
+			"version": "1.0.2",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -40331,7 +40298,7 @@
 		},
 		"packages/codemods": {
 			"name": "@tablecheck/codemods",
-			"version": "1.0.1",
+			"version": "1.0.2",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -40623,7 +40590,7 @@
 		},
 		"packages/commitlint-config": {
 			"name": "@tablecheck/commitlint-config",
-			"version": "1.0.1",
+			"version": "1.0.2",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -40638,7 +40605,7 @@
 		},
 		"packages/eslint-config": {
 			"name": "@tablecheck/eslint-config",
-			"version": "1.1.1",
+			"version": "1.1.2",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -40686,7 +40653,7 @@
 		},
 		"packages/scripts": {
 			"name": "@tablecheck/scripts",
-			"version": "1.1.2",
+			"version": "1.1.5",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -41314,7 +41281,7 @@
 		},
 		"packages/semantic-release-config": {
 			"name": "@tablecheck/semantic-release-config",
-			"version": "1.0.1",
+			"version": "1.0.2",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -41372,23 +41339,6 @@
 			"resolved": "https://registry.npmjs.org/@auto-it/bot-list/-/bot-list-10.30.0.tgz",
 			"integrity": "sha512-ZOWmFpIPid7bRA065e1YwA5iaJITZH5HoINvUz258kSG9+LFd+9EzDeUl4+Lygqy7MRwPC0TpHv2siv25Sw7Hg==",
 			"dev": true
-		},
-		"@auto-it/conventional-commits": {
-			"version": "10.30.0",
-			"resolved": "https://registry.npmjs.org/@auto-it/conventional-commits/-/conventional-commits-10.30.0.tgz",
-			"integrity": "sha512-K8EN+aaoMsfklTEqvDkfFmwPUSGDh5PhkqrM6w7d6VIvgHRBIWWXY95w3MrATxpFFqunwiCOaIPWGChuJ3tLFg==",
-			"dev": true,
-			"requires": {
-				"@auto-it/core": "10.30.0",
-				"array.prototype.flatmap": "^1.2.2",
-				"conventional-changelog-core": "^4.2.0",
-				"conventional-changelog-preset-loader": "^2.3.4",
-				"conventional-commits-parser": "^3.1.0",
-				"endent": "^2.0.1",
-				"fp-ts": "^2.5.3",
-				"io-ts": "^2.1.2",
-				"tslib": "2.1.0"
-			}
 		},
 		"@auto-it/core": {
 			"version": "10.30.0",
@@ -43243,7 +43193,7 @@
 		},
 		"@emotion/styled": {
 			"version": "11.3.0",
-			"resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.3.0.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/@emotion/styled/-/styled-11.3.0.tgz",
 			"integrity": "sha512-fUoLcN3BfMiLlRhJ8CuPUMEyKkLEoM+n+UyAbnqGEsCd5IzKQ7VQFLtzpJOaCD2/VR2+1hXQTnSZXVJeiTNltA==",
 			"requires": {
 				"@babel/runtime": "^7.13.10",
@@ -43255,7 +43205,7 @@
 			"dependencies": {
 				"@emotion/is-prop-valid": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.1.0.tgz",
+					"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/@emotion/is-prop-valid/-/is-prop-valid-1.1.0.tgz",
 					"integrity": "sha512-9RkilvXAufQHsSsjQ3PIzSns+pxuX4EW8EbGeSPjZMHuMx6z/MOzb9LpqNieQX4F3mre3NWS2+X3JNRHTQztUQ==",
 					"requires": {
 						"@emotion/memoize": "^0.7.4"
@@ -43263,7 +43213,7 @@
 				},
 				"@emotion/serialize": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
+					"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/@emotion/serialize/-/serialize-1.0.2.tgz",
 					"integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
 					"requires": {
 						"@emotion/hash": "^0.8.0",
@@ -43275,12 +43225,12 @@
 				},
 				"@emotion/utils": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+					"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/@emotion/utils/-/utils-1.0.0.tgz",
 					"integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
 				},
 				"csstype": {
 					"version": "3.0.8",
-					"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
+					"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/csstype/-/csstype-3.0.8.tgz",
 					"integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
 				}
 			}
@@ -57856,7 +57806,7 @@
 		},
 		"immer": {
 			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/immer/-/immer-9.0.5.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/immer/-/immer-9.0.5.tgz",
 			"integrity": "sha512-2WuIehr2y4lmYz9gaQzetPR2ECniCifk4ORaQbU3g5EalLt+0IVTosEPJ5BoYl/75ky2mivzdRzV8wWgQGOSYQ=="
 		},
 		"import-cwd": {
@@ -58014,7 +57964,7 @@
 		},
 		"inquirer": {
 			"version": "8.1.2",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.1.2.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/inquirer/-/inquirer-8.1.2.tgz",
 			"integrity": "sha512-DHLKJwLPNgkfwNmsuEUKSejJFbkv0FMO9SMiQbjI3n5NQuCrSIBqP66ggqyz2a6t2qEolKrMjhQ3+W/xXgUQ+Q==",
 			"requires": {
 				"ansi-escapes": "^4.2.1",
@@ -58035,7 +57985,7 @@
 			"dependencies": {
 				"ora": {
 					"version": "5.4.1",
-					"resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+					"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/ora/-/ora-5.4.1.tgz",
 					"integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
 					"requires": {
 						"bl": "^4.1.0",
@@ -58051,7 +58001,7 @@
 				},
 				"rxjs": {
 					"version": "7.3.0",
-					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.3.0.tgz",
+					"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/rxjs/-/rxjs-7.3.0.tgz",
 					"integrity": "sha512-p2yuGIg9S1epc3vrjKf6iVb3RCaAYjYskkO+jHIaV0IjOPlJop4UnodOoFb2xeNwlguqLYvGw1b1McillYb5Gw==",
 					"requires": {
 						"tslib": "~2.1.0"
@@ -60741,7 +60691,7 @@
 		},
 		"jscodeshift": {
 			"version": "0.13.0",
-			"resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.13.0.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/jscodeshift/-/jscodeshift-0.13.0.tgz",
 			"integrity": "sha512-FNHLuwh7TeI0F4EzNVIRwUSxSqsGWM5nTv596FK4NfBnEEKFpIcyFeG559DMFGHSTIYA5AY4Fqh2cBrJx0EAwg==",
 			"requires": {
 				"@babel/core": "^7.13.16",
@@ -60767,7 +60717,7 @@
 			"dependencies": {
 				"braces": {
 					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/braces/-/braces-2.3.2.tgz",
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"requires": {
 						"arr-flatten": "^1.1.0",
@@ -60784,7 +60734,7 @@
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
 								"is-extendable": "^0.1.0"
@@ -60794,7 +60744,7 @@
 				},
 				"fill-range": {
 					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/fill-range/-/fill-range-4.0.0.tgz",
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"requires": {
 						"extend-shallow": "^2.0.1",
@@ -60805,7 +60755,7 @@
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
 								"is-extendable": "^0.1.0"
@@ -60815,17 +60765,17 @@
 				},
 				"is-buffer": {
 					"version": "1.1.6",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+					"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/is-buffer/-/is-buffer-1.1.6.tgz",
 					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 				},
 				"is-extendable": {
 					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+					"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/is-extendable/-/is-extendable-0.1.1.tgz",
 					"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
 				},
 				"is-number": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"requires": {
 						"kind-of": "^3.0.2"
@@ -60833,7 +60783,7 @@
 					"dependencies": {
 						"kind-of": {
 							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
 								"is-buffer": "^1.1.5"
@@ -60843,12 +60793,12 @@
 				},
 				"isobject": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/isobject/-/isobject-3.0.1.tgz",
 					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 				},
 				"micromatch": {
 					"version": "3.1.10",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/micromatch/-/micromatch-3.1.10.tgz",
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"requires": {
 						"arr-diff": "^4.0.0",
@@ -60868,7 +60818,7 @@
 				},
 				"recast": {
 					"version": "0.20.5",
-					"resolved": "https://registry.npmjs.org/recast/-/recast-0.20.5.tgz",
+					"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/recast/-/recast-0.20.5.tgz",
 					"integrity": "sha512-E5qICoPoNL4yU0H0NoBDntNB0Q5oMSNh9usFctYniLBluTthi3RsQVBXIJNbApOlvSwW/RGxIuokPcAc59J5fQ==",
 					"requires": {
 						"ast-types": "0.14.2",
@@ -60879,12 +60829,12 @@
 				},
 				"source-map": {
 					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"to-regex-range": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+					"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/to-regex-range/-/to-regex-range-2.1.1.tgz",
 					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 					"requires": {
 						"is-number": "^3.0.0",
@@ -60893,7 +60843,7 @@
 				},
 				"write-file-atomic": {
 					"version": "2.4.3",
-					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+					"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
 					"integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
 					"requires": {
 						"graceful-fs": "^4.1.11",
@@ -72956,7 +72906,7 @@
 		},
 		"webpack-manifest-plugin": {
 			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-4.0.2.tgz",
+			"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/webpack-manifest-plugin/-/webpack-manifest-plugin-4.0.2.tgz",
 			"integrity": "sha512-Ld6j05pRblXAVoX8xdXFDsc/s97cFnR1FOmQawhTSlp6F6aeU1Jia5aqTmDpkueaAz8g9sXpgSOqmEgVAR61Xw==",
 			"requires": {
 				"tapable": "^2.0.0",
@@ -72965,12 +72915,12 @@
 			"dependencies": {
 				"source-map": {
 					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				},
 				"webpack-sources": {
 					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.3.1.tgz",
+					"resolved": "https://tablecheck-934763610305.d.codeartifact.ap-northeast-1.amazonaws.com:443/npm/tablecheck/webpack-sources/-/webpack-sources-2.3.1.tgz",
 					"integrity": "sha512-y9EI9AO42JjEcrTJFOYmVywVZdKVUfOvDUPsJea5GIr1JOEGFVqwlY2K098fFoIjOkDzHn2AjRvM8dsBZu+gCA==",
 					"requires": {
 						"source-list-map": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "devDependencies": {
     "@auto-it/all-contributors": "10.30.0",
-    "@auto-it/conventional-commits": "10.30.0",
     "@auto-it/first-time-contributor": "10.30.0",
     "@auto-it/npm": "10.30.0",
     "@auto-it/released": "10.30.0",


### PR DESCRIPTION
Attempting fix from https://github.com/intuit/auto/issues/1030

Also implementing FL-464
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/eslint-config@1.2.0-canary.20.659b35688f1eb28a1d75986d6015b16e70a7a897.0
  npm install @tablecheck/scripts@1.2.0-canary.20.659b35688f1eb28a1d75986d6015b16e70a7a897.0
  # or 
  yarn add @tablecheck/eslint-config@1.2.0-canary.20.659b35688f1eb28a1d75986d6015b16e70a7a897.0
  yarn add @tablecheck/scripts@1.2.0-canary.20.659b35688f1eb28a1d75986d6015b16e70a7a897.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
