### PR TITLE
feat(eslint-config): add past tense boolean prefixes

### DIFF
--- a/packages/eslint-config/rules/namingConvention.js
+++ b/packages/eslint-config/rules/namingConvention.js
@@ -30,7 +30,17 @@ module.exports = {
       selector: 'variable',
       types: ['boolean'],
       format: ['PascalCase'],
-      prefix: ['is', 'should', 'has', 'can', 'did', 'will', 'allow']
+      prefix: [
+        'is',
+        'was',
+        'should',
+        'has',
+        'had',
+        'can',
+        'did',
+        'will',
+        'allow'
+      ]
     },
     {
       selector: 'variable',


### PR DESCRIPTION
This allows the more syntactically readable past tense versions of certain boolean prefixes.

* `isPrevSelected` => `wasSelected`
* `hasPrevSelection` => `hadSelection`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/eslint-config@1.3.0-canary.23.d3869a98864d6f21859a1b7c4ecc9f3ac8c30350.0
  npm install @tablecheck/scripts@1.3.0-canary.23.d3869a98864d6f21859a1b7c4ecc9f3ac8c30350.0
  # or 
  yarn add @tablecheck/eslint-config@1.3.0-canary.23.d3869a98864d6f21859a1b7c4ecc9f3ac8c30350.0
  yarn add @tablecheck/scripts@1.3.0-canary.23.d3869a98864d6f21859a1b7c4ecc9f3ac8c30350.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
