### PR TITLE
fix(scripts): add audit cli cache option

### DIFF
--- a/packages/scripts/scripts/auditjs.js
+++ b/packages/scripts/scripts/auditjs.js
@@ -19,7 +19,7 @@ const argv = getArgv({
   }
 });
 
-const auditjsArgs = ['ossi', '--dev', '--quiet'];
+const auditjsArgs = ['ossi', '--dev', '--quiet', '--cache=cache/audit'];
 if (process.env.OSSI_USERNAME && process.env.OSSI_TOKEN) {
   auditjsArgs.push(`-u=${process.env.OSSI_USERNAME}`);
   auditjsArgs.push(`-p=${process.env.OSSI_TOKEN}`);


### PR DESCRIPTION
On some system latest audit version uses root folder as target
for cache output. Providing cache option to cli args fixes the issue
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/scripts@1.5.0-canary.26.9e88af10d104c1f8c28870af1da9e5aa15ed95c1.0
  # or 
  yarn add @tablecheck/scripts@1.5.0-canary.26.9e88af10d104c1f8c28870af1da9e5aa15ed95c1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
