### PR TITLE
fix: add cypress types for odd edge cases

### DIFF
--- a/packages/scripts/scripts/init.js
+++ b/packages/scripts/scripts/init.js
@@ -258,7 +258,7 @@ async function initProject() {
 
   await execa(
     'npm',
-    ['install', '--save-dev', '--save-exact', 'prettier@^2', 'husky@7'],
+    ['install', '--save-dev', '--save-exact', 'prettier@2', 'husky@7'],
     execaOptions
   );
 
@@ -292,11 +292,15 @@ async function initProject() {
     path.join(paths.cwd, '.husky', 'pre-commit')
   );
 
-  const { peerDependencies, optionalDependencies } = require(require.resolve(
-    '../package.json'
-  ));
+  const {
+    peerDependencies,
+    optionalDependencies,
+    dependencies
+  } = require(require.resolve('../package.json'));
   const devDependencies = [
-    `babel-preset-razzle@${optionalDependencies.razzle}`
+    `babel-preset-razzle@${optionalDependencies.razzle}`,
+    // technically this isn't necessary but a lot of other apps use this dependency inside package.json as a typescript check
+    `typescript@${dependencies.typescript}`
   ].concat(
     Object.keys(peerDependencies).map(
       (key) => `${key}@${peerDependencies[key]}`
@@ -306,7 +310,7 @@ async function initProject() {
     (key) => `${key}@${optionalDependencies[key]}`
   );
 
-  devDependencies.push('@tablecheck/scripts', '@commitlint/cli@11');
+  devDependencies.push('@tablecheck/scripts', '@commitlint/cli');
 
   appDependencies.push(
     'concurrently',
@@ -356,7 +360,7 @@ async function initProject() {
   let packageScripts = { ...basePackageScripts };
 
   if (scriptType === SCRIPTS.LERNA) {
-    devDependencies.push('@commitlint/config-lerna-scopes@11');
+    devDependencies.push('@commitlint/config-lerna-scopes');
     fs.copyFileSync(
       path.join(templatesDirectory, 'commitlint.lerna.config.js'),
       path.join(paths.cwd, 'commitlint.config.js')

--- a/packages/scripts/scripts/utils/configureTypescript.js
+++ b/packages/scripts/scripts/utils/configureTypescript.js
@@ -277,7 +277,8 @@ module.exports = {
             ...config.compilerOptions,
             baseUrl: path.relative(paths.cypress, path.join(paths.cwd, 'src')),
             isolatedModules: false,
-            noEmit: true
+            noEmit: true,
+            types: ['cypress', 'node']
           }
         },
         true


### PR DESCRIPTION
When the git root and the package.json are not in the same folder typescript doesn't correctly detect our usage of typescript like other projects do.
Also adding in some extra checks and updates to the init scripts.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/scripts@1.5.1-canary.27.2ddfba904a168e97e40a6ad639c07c3ded844e61.0
  # or 
  yarn add @tablecheck/scripts@1.5.1-canary.27.2ddfba904a168e97e40a6ad639c07c3ded844e61.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
