### PR TITLE
fix(scripts): turn off prop types rule

### DIFF
--- a/packages/eslint-config/rules/react.js
+++ b/packages/eslint-config/rules/react.js
@@ -8,6 +8,7 @@ module.exports = {
   'react/jsx-filename-extension': 'off',
   // irritating, TS handles this better
   'react/static-property-placement': 'off',
+  'react/prop-types': 'off',
 
   // These cause typing conflicts
   'react/require-default-props': ['off'],


### PR DESCRIPTION
Reason: Typescript makes it better. Eslint may not figure them out properly in case of deeply nested interfaces (generic)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/eslint-config@1.5.0-canary.28.ea0962c958aa5c2cbeec2a7380ef6d5557264883.0
  npm install @tablecheck/scripts@1.6.0-canary.28.ea0962c958aa5c2cbeec2a7380ef6d5557264883.0
  # or 
  yarn add @tablecheck/eslint-config@1.5.0-canary.28.ea0962c958aa5c2cbeec2a7380ef6d5557264883.0
  yarn add @tablecheck/scripts@1.6.0-canary.28.ea0962c958aa5c2cbeec2a7380ef6d5557264883.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
