### PR TITLE
fix: eslint plugin can't find tsconfig in precommit

### DIFF
--- a/packages/eslint-config/overrides/cypress.js
+++ b/packages/eslint-config/overrides/cypress.js
@@ -20,7 +20,8 @@ module.exports = merge(require('./typescript'), {
   parserOptions: {
     ecmaVersion: 9,
     sourceType: 'module',
-    project: ['./cypress/tsconfig.json']
+    // defining both of these to prevent a bug in precommit staged linter from failing in some cases
+    project: ['./cypress/tsconfig.json', './tsconfig.json']
   },
   env: {
     'cypress/globals': true


### PR DESCRIPTION
Sometimes the lint-staged eslint couldn't find the cypress configs correctly, this fixes that issue.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/eslint-config@1.5.1-canary.29.efab3d29f4cf489567f85982e3735009bb6db61a.0
  npm install @tablecheck/scripts@1.6.1-canary.29.efab3d29f4cf489567f85982e3735009bb6db61a.0
  # or 
  yarn add @tablecheck/eslint-config@1.5.1-canary.29.efab3d29f4cf489567f85982e3735009bb6db61a.0
  yarn add @tablecheck/scripts@1.6.1-canary.29.efab3d29f4cf489567f85982e3735009bb6db61a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
