### PR TITLE
feat(semantic-release-config): change gitlab to github

### DIFF
--- a/auditjs.json
+++ b/auditjs.json
@@ -32,6 +32,9 @@
     },
     {
       "id": "9112787d-940e-42c8-a77b-a8e16735d6bd"
+    },
+    {
+      "id": "849e9fed-44e8-4593-a4ca-61026c4b454f"
     }
   ],
   "affected": [
@@ -256,6 +259,22 @@
           "cvssScore": 5.3,
           "cvssVector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
           "reference": "https://ossindex.sonatype.org/vulnerability/9112787d-940e-42c8-a77b-a8e16735d6bd?component-type=npm&component-name=just-diff-apply&utm_source=auditjs&utm_medium=integration&utm_content=4.0.28"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/ansi-html@0.0.7",
+      "description": "An elegant lib that converts the chalked (ANSI) text to HTML.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/ansi-html@0.0.7?utm_source=auditjs&utm_medium=integration&utm_content=4.0.28",
+      "vulnerabilities": [
+        {
+          "id": "849e9fed-44e8-4593-a4ca-61026c4b454f",
+          "title": "[CVE-2021-23424] This affects all versions of package ansi-html. If an attacker provides a malici...",
+          "description": "This affects all versions of package ansi-html. If an attacker provides a malicious string, it will get stuck processing the input for an extremely long time.",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2021-23424",
+          "reference": "https://ossindex.sonatype.org/vulnerability/849e9fed-44e8-4593-a4ca-61026c4b454f?component-type=npm&component-name=ansi-html&utm_source=auditjs&utm_medium=integration&utm_content=4.0.28"
         }
       ]
     }

--- a/packages/semantic-release-config/README.md
+++ b/packages/semantic-release-config/README.md
@@ -3,14 +3,14 @@
 A [semantic-release](https://semantic-release.gitbook.io/semantic-release/) config, used with our commitlint settings and does the following steps.
 
 1. Increments the version according to conventional-commits.
-2. Publishes a "GitLab Release" with correctly linked JIRA tickets
+2. Publishes a "GitHub Release" with correctly linked JIRA tickets
 3. Publishes a message to a slack webhook.
 
 ## Required CI Variables
 
 | Variable      | Usage                                                                   | Where to get it from                                                                                                                                      |
 | ------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| GITLAB_TOKEN  | API Token Used for parsing previous releases and publishing the new one | To please contact a GitLab admin or copy from another project. Should be generated from the `TableCheck Gitlab Bot`                                       |
+| GITHUB_TOKEN  | API Token Used for parsing previous releases and publishing the new one | Available in semaphoreci `github-releases` secret or see https://github.com/semantic-release/github#github-authentication                                 |
 | SLACK_WEBHOOK | Used for posting slack updates                                          | Go to the `Semantic Release` App and generate a new webhook for the channel you wish to post to. https://api.slack.com/apps/A021U4J1CQ4/incoming-webhooks |
 
 ## Usage

--- a/packages/semantic-release-config/README.stories.mdx
+++ b/packages/semantic-release-config/README.stories.mdx
@@ -5,14 +5,14 @@ import { Meta } from '@storybook/addon-docs/blocks';
 A [semantic-release](https://semantic-release.gitbook.io/semantic-release/) config, used with our commitlint settings and does the following steps.
 
 1. Increments the version according to conventional-commits.
-2. Publishes a "GitLab Release" with correctly linked JIRA tickets
+2. Publishes a "GitHub Release" with correctly linked JIRA tickets
 3. Publishes a message to a slack webhook.
 
 ## Required CI Variables
 
 | Variable      | Usage                                                                   | Where to get it from                                                                                                                                      |
 | ------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| GITLAB_TOKEN  | API Token Used for parsing previous releases and publishing the new one | To please contact a GitLab admin or copy from another project. Should be generated from the `TableCheck Gitlab Bot`                                       |
+| GITHUB_TOKEN  | API Token Used for parsing previous releases and publishing the new one | Available in semaphoreci `github-releases` secret or see https://github.com/semantic-release/github#github-authentication                                 |
 | SLACK_WEBHOOK | Used for posting slack updates                                          | Go to the `Semantic Release` App and generate a new webhook for the channel you wish to post to. https://api.slack.com/apps/A021U4J1CQ4/incoming-webhooks |
 
 ## Usage

--- a/packages/semantic-release-config/index.js
+++ b/packages/semantic-release-config/index.js
@@ -82,7 +82,7 @@ module.exports = {
         }
       }
     ],
-    '@semantic-release/gitlab',
+    '@semantic-release/github',
     [
       'semantic-release-slack-bot',
       // make sure that SLACK_WEBHOOK env var is set in CI config

--- a/packages/semantic-release-config/package.json
+++ b/packages/semantic-release-config/package.json
@@ -14,7 +14,6 @@
   ],
   "dependencies": {
     "@semantic-release/commit-analyzer": "^8.0.1",
-    "@semantic-release/gitlab": "^6.2.2",
     "@semantic-release/release-notes-generator": "^9.0.3",
     "semantic-release-slack-bot": "^2.1.1"
   },


### PR DESCRIPTION
BREAKING-CHANGE: no longer supports gitlab, only github

This is to support moving our codebases from gitlab to GitHub
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/semantic-release-config@2.0.0-canary.31.200a1ba6b2e84277bca8149dc7e11e742a56c683.0
  # or 
  yarn add @tablecheck/semantic-release-config@2.0.0-canary.31.200a1ba6b2e84277bca8149dc7e11e742a56c683.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
