### PR TITLE
feat(scripts): support absolute path for cypress folder

### DIFF
--- a/packages/scripts/scripts/utils/configureTypescript.js
+++ b/packages/scripts/scripts/utils/configureTypescript.js
@@ -150,19 +150,30 @@ module.exports = {
     }
     if (fs.existsSync(paths.cypress)) {
       eslintRoots.push('cypress');
+      packageConfig.exclude.push('src/**/*.cypress.tsx', 'src/**/*.cypress.ts');
+      const compilerPaths = {
+        // this let's us import cypress files from an absolute path in our component tests
+        '#cypress/*': ['../cypress/*']
+      };
+      packageConfig.compilerOptions.paths = compilerPaths;
       writeTsConfig(
         path.join(paths.cypress, 'tsconfig.json'),
         {
           ...packageConfig,
           extends: '@tablecheck/scripts/tsconfig/base.json',
-          include: ['**/*.ts'],
+          include: [
+            '**/*.ts',
+            '../src/**/*.cypress.tsx',
+            '../src/**/*.cypress.ts'
+          ],
           compilerOptions: {
             baseUrl: path.relative(paths.cypress, path.join(paths.cwd, 'src')),
             lib: ['dom', 'dom.iterable', 'esnext'],
             module: 'esnext',
             target: 'es5',
             noEmit: true,
-            isolatedModules: false
+            isolatedModules: false,
+            paths: compilerPaths
           }
         },
         true
@@ -253,11 +264,16 @@ module.exports = {
       }
     };
     const runnerConfigPath = path.join(paths.cwd, 'tsconfig.json');
-    writeTsConfig(runnerConfigPath, config, true);
 
     if (fs.existsSync(paths.cypress)) {
+      config.exclude.push('src/**/*.cypress.tsx', 'src/**/*.cypress.ts');
+      const compilerPaths = {
+        // this let's us import cypress files from an absolute path in our component tests
+        '#cypress/*': ['../cypress/*']
+      };
+      config.compilerOptions.paths = compilerPaths;
       writeTsConfig(
-        path.join(paths.cwd, 'tsconfig.eslint.json'),
+        path.join(compilerPaths.cwd, 'tsconfig.eslint.json'),
         {
           ...config,
           include: include.concat(systemSettings.additionalRoots || []),
@@ -270,13 +286,20 @@ module.exports = {
         true
       );
       writeTsConfig(
-        path.join(paths.cypress, 'tsconfig.json'),
+        path.join(compilerPaths.cypress, 'tsconfig.json'),
         {
           ...config,
-          include: ['**/*.ts'],
+          include: [
+            '**/*.ts',
+            '../src/**/*.cypress.tsx',
+            '../src/**/*.cypress.ts'
+          ],
           compilerOptions: {
             ...config.compilerOptions,
-            baseUrl: path.relative(paths.cypress, path.join(paths.cwd, 'src')),
+            baseUrl: path.relative(
+              compilerPaths.cypress,
+              path.join(compilerPaths.cwd, 'src')
+            ),
             isolatedModules: false,
             noEmit: true,
             types: ['cypress', 'node']
@@ -285,6 +308,7 @@ module.exports = {
         true
       );
     }
+    writeTsConfig(runnerConfigPath, config, true);
 
     return runnerConfigPath;
   },


### PR DESCRIPTION
This fixes the issue with needing relative paths in cypress component tests that become extremely long.

The new import path is `import '#cypress/support/commands'` at present.

Reasoning is as follows;
* Straight `import 'cypress/support/commands'` is a little unclear as unlike our other absolute path imports this folder isn't a child of './src'. Also it clashes with the actual cypress package `import { CyHttpMessages } from 'cypress/types/net-stubbing';`
* Abbreviations like `cy` are also unclear as this again is often used by cypress usage/implementation (not as a package though)
* `local-cypress` instead of `#cypress` is also up for debate, I prefer the `#` as it's shorter and more clear that it's different.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/scripts@1.8.0-canary.33.38f66ef7c589077dc6e02d72250f01533188015b.0
  # or 
  yarn add @tablecheck/scripts@1.8.0-canary.33.38f66ef7c589077dc6e02d72250f01533188015b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
