### PR TITLE
fix(scripts): revert bad variable rename

### DIFF
--- a/packages/scripts/scripts/utils/configureTypescript.js
+++ b/packages/scripts/scripts/utils/configureTypescript.js
@@ -273,7 +273,7 @@ module.exports = {
       };
       config.compilerOptions.paths = compilerPaths;
       writeTsConfig(
-        path.join(compilerPaths.cwd, 'tsconfig.eslint.json'),
+        path.join(paths.cwd, 'tsconfig.eslint.json'),
         {
           ...config,
           include: include.concat(systemSettings.additionalRoots || []),
@@ -286,7 +286,7 @@ module.exports = {
         true
       );
       writeTsConfig(
-        path.join(compilerPaths.cypress, 'tsconfig.json'),
+        path.join(paths.cypress, 'tsconfig.json'),
         {
           ...config,
           include: [
@@ -296,10 +296,7 @@ module.exports = {
           ],
           compilerOptions: {
             ...config.compilerOptions,
-            baseUrl: path.relative(
-              compilerPaths.cypress,
-              path.join(compilerPaths.cwd, 'src')
-            ),
+            baseUrl: path.relative(paths.cypress, path.join(paths.cwd, 'src')),
             isolatedModules: false,
             noEmit: true,
             types: ['cypress', 'node']


### PR DESCRIPTION
Renaming of paths to compilerPaths in previous PR caused errors to occur.

In version 1.8.0 the following error occurs on install and the whole npm install fails.

```
npm ERR! code 1
npm ERR! path /Users/simeon.cheeseman/Development/settings-frontend/node_modules/@tablecheck/scripts
npm ERR! command failed
npm ERR! command sh -c ./bin/postinstall.js
npm ERR! Generating definition file for node-config...  Done!
npm ERR! node:internal/validators:119
npm ERR!     throw new ERR_INVALID_ARG_TYPE(name, 'string', value);
npm ERR!     ^
npm ERR! 
npm ERR! TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
npm ERR!     at new NodeError (node:internal/errors:363:5)
npm ERR!     at validateString (node:internal/validators:119:11)
npm ERR!     at Object.join (node:path:1172:7)
npm ERR!     at configureAppTypescript (/Users/simeon.cheeseman/Development/settings-frontend/node_modules/@tablecheck/scripts/scripts/utils/configureTypescript.js:276:14)
npm ERR!     at Object.<anonymous> (/Users/simeon.cheeseman/Development/settings-frontend/node_modules/@tablecheck/scripts/bin/postinstall.js:23:5)
npm ERR!     at Module._compile (node:internal/modules/cjs/loader:1095:14)
npm ERR!     at Object.Module._extensions..js (node:internal/modules/cjs/loader:1124:10)
npm ERR!     at Module.load (node:internal/modules/cjs/loader:975:32)
npm ERR!     at Function.Module._load (node:internal/modules/cjs/loader:816:12)
npm ERR!     at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:79:12) {
npm ERR!   code: 'ERR_INVALID_ARG_TYPE'
npm ERR! }

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/simeon.cheeseman/.npm/_logs/2021-11-25T06_29_20_298Z-debug.log

```

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/scripts@1.8.1-canary.34.21d822c78a1a3d4b96963baa0af85b6e6b3d4c9b.0
  # or 
  yarn add @tablecheck/scripts@1.8.1-canary.34.21d822c78a1a3d4b96963baa0af85b6e6b3d4c9b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
