### PR TITLE
fix(scripts): typescript config for cypress

### DIFF
--- a/packages/scripts/scripts/utils/configureTypescript.js
+++ b/packages/scripts/scripts/utils/configureTypescript.js
@@ -161,10 +161,12 @@ module.exports = {
         {
           ...packageConfig,
           extends: '@tablecheck/scripts/tsconfig/base.json',
+          exclude: ['node_modules'],
           include: [
             '**/*.ts',
             '../src/**/*.cypress.tsx',
-            '../src/**/*.cypress.ts'
+            '../src/**/*.cypress.ts',
+            '../src/definitions/**/*.ts'
           ],
           compilerOptions: {
             baseUrl: path.relative(paths.cypress, path.join(paths.cwd, 'src')),
@@ -289,10 +291,12 @@ module.exports = {
         path.join(paths.cypress, 'tsconfig.json'),
         {
           ...config,
+          exclude: ['node_modules'],
           include: [
             '**/*.ts',
             '../src/**/*.cypress.tsx',
-            '../src/**/*.cypress.ts'
+            '../src/**/*.cypress.ts',
+            '../src/definitions/**/*.ts'
           ],
           compilerOptions: {
             ...config.compilerOptions,


### PR DESCRIPTION
Fixes an issue where cypress didn't know about any definition files in the src folder causing errors in some cases.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/scripts@1.8.2-canary.35.63da3bc43fcaca62ffc15365f228145018e5f383.0
  # or 
  yarn add @tablecheck/scripts@1.8.2-canary.35.63da3bc43fcaca62ffc15365f228145018e5f383.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
