### PR TITLE
feat(semantic-release-config): add CI utility output file

### DIFF
--- a/packages/semantic-release-config/index.js
+++ b/packages/semantic-release-config/index.js
@@ -91,6 +91,14 @@ module.exports = {
         notifyOnFail: false,
         markdownReleaseNotes: true
       }
+    ],
+    [
+      '@semantic-release/exec',
+      {
+        successCmd:
+          // eslint-disable-next-line no-template-curly-in-string
+          'echo "${nextRelease.name}" > version.txt'
+      }
     ]
   ]
 };

--- a/packages/semantic-release-config/package.json
+++ b/packages/semantic-release-config/package.json
@@ -14,6 +14,7 @@
   ],
   "dependencies": {
     "@semantic-release/commit-analyzer": "^8.0.1",
+    "@semantic-release/exec": "^6.0.2",
     "@semantic-release/release-notes-generator": "^9.0.3",
     "semantic-release-slack-bot": "^2.1.1"
   },


### PR DESCRIPTION
Adding an exec step on success to write a version.txt file that can be read by CI utilities or other tools. This is a more generic version of the custom script that was used in settings-frontend.

We are using a file as this can often be passed between different CI jobs far more easily than an environment variable or similar. Also as we rely 100% on tags and not the package.json version for our versioning we can't just re-read the package.json file again.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/semantic-release-config@2.1.0-canary.37.b2e88a59c5d0835661fc74951ad67f1d2ce5746f.0
  # or 
  yarn add @tablecheck/semantic-release-config@2.1.0-canary.37.b2e88a59c5d0835661fc74951ad67f1d2ce5746f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
