### PR TITLE
fix(scripts): correctly fail runLint when errors are present

### DIFF
--- a/packages/scripts/scripts/lint.js
+++ b/packages/scripts/scripts/lint.js
@@ -96,6 +96,8 @@ const argv = getArgv({
   }
 
   const eslintRcFile = validateEslintrc();
+  const isThisRepo =
+    fs.readJsonSync(paths.appPackageJson).name === 'tablecheck-react-system';
 
   console.log(
     chalk.blue(`\nChecking${argv.fix ? ' and fixing' : ''} files matching:`)
@@ -107,7 +109,7 @@ const argv = getArgv({
   if (argv.fix) {
     await formatPackages();
     console.log('');
-  } else if (!(await lintAllPackages())) {
+  } else if (!isThisRepo && !(await lintAllPackages())) {
     process.exit(1);
     return;
   }
@@ -163,7 +165,7 @@ const argv = getArgv({
     .map((globPath) => path.relative(paths.cwd, globPath));
   const spawnedEslint = runEslint(eslintRcFile, eslintPaths, argv.fix);
 
-  const spawnedPrettier = spawnedEslint
+  const spawnedPrettier = (argv.fix ? spawnedEslint : Promise.resolve())
     .catch(() => {})
     .then(() => {
       const prettierArgs = ['--ignore-unknown'];

--- a/packages/scripts/scripts/utils/package.js
+++ b/packages/scripts/scripts/utils/package.js
@@ -88,8 +88,6 @@ const prettyFormatOptions = {
 };
 
 async function evaluatePackage({ dependencies, devDependencies, name }) {
-  // special exception for this repository
-  if (name.match(/(^|@)tc-react-system/gi)) return [];
   // package.json version keys check
   const invalidVersionValues = [];
   const lernaPaths = await getLernaPaths();

--- a/packages/scripts/scripts/utils/runEslint.js
+++ b/packages/scripts/scripts/utils/runEslint.js
@@ -5,6 +5,7 @@ const { ESLint } = require('eslint');
 const paths = require('../../config/paths');
 
 async function runEslint(eslintRcFile, eslintPaths, shouldAutoFix) {
+  let results = [];
   try {
     const overrideConfigFile =
       require(paths.appPackageJson).name === 'tablecheck-react-system'
@@ -17,7 +18,7 @@ async function runEslint(eslintRcFile, eslintPaths, shouldAutoFix) {
       useEslintrc: false,
       errorOnUnmatchedPattern: false
     });
-    const results = await eslint.lintFiles(eslintPaths);
+    results = await eslint.lintFiles(eslintPaths);
     const cliFormatter = await eslint.loadFormatter(
       require.resolve('../../config/eslintStylishFormatter.js')
     );
@@ -32,6 +33,13 @@ async function runEslint(eslintRcFile, eslintPaths, shouldAutoFix) {
     );
   } catch (e) {
     console.error('eslint error', e);
+    throw e;
+  }
+  for (let i = 0; i < results.length; i += 1) {
+    const result = results[i];
+    if (result.errorCount || result.fatalErrorCount) {
+      throw new Error('Eslint detected errors');
+    }
   }
 }
 

--- a/packages/scripts/tests/dependencyValidation.spec.js
+++ b/packages/scripts/tests/dependencyValidation.spec.js
@@ -87,14 +87,6 @@ describe('lintPackageVersions', () => {
       ]
     ],
     [
-      'handles special dependency for tc-react-system',
-      'tc-react-system',
-      {
-        '@tablecheck/eslint-config': '*'
-      },
-      []
-    ],
-    [
       'handles lerna mono repo packages',
       '@lerna-repo/package',
       {


### PR DESCRIPTION
Fixes a bug where the lint script would pass and exit with 0 even if there were eslint errors.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/scripts@1.9.1-canary.38.7a88e8b81e009061cd1d3cde4abd9376e44ceac4.0
  npm install @tablecheck/semantic-release-config@2.1.1-canary.38.7a88e8b81e009061cd1d3cde4abd9376e44ceac4.0
  # or 
  yarn add @tablecheck/scripts@1.9.1-canary.38.7a88e8b81e009061cd1d3cde4abd9376e44ceac4.0
  yarn add @tablecheck/semantic-release-config@2.1.1-canary.38.7a88e8b81e009061cd1d3cde4abd9376e44ceac4.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
