### PR TITLE
docs: update semantic-release-config readme

### DIFF
--- a/packages/semantic-release-config/README.md
+++ b/packages/semantic-release-config/README.md
@@ -3,8 +3,9 @@
 A [semantic-release](https://semantic-release.gitbook.io/semantic-release/) config, used with our commitlint settings and does the following steps.
 
 1. Increments the version according to conventional-commits.
-2. Publishes a "GitHub Release" with correctly linked JIRA tickets
+2. Publishes a "GitHub Release" with correctly linked JIRA tickets.
 3. Publishes a message to a slack webhook.
+4. Outputs the new version to `version.txt` for ease of use in other reports.
 
 ## Required CI Variables
 

--- a/packages/semantic-release-config/README.stories.mdx
+++ b/packages/semantic-release-config/README.stories.mdx
@@ -5,8 +5,9 @@ import { Meta } from '@storybook/addon-docs/blocks';
 A [semantic-release](https://semantic-release.gitbook.io/semantic-release/) config, used with our commitlint settings and does the following steps.
 
 1. Increments the version according to conventional-commits.
-2. Publishes a "GitHub Release" with correctly linked JIRA tickets
+2. Publishes a "GitHub Release" with correctly linked JIRA tickets.
 3. Publishes a message to a slack webhook.
+4. Outputs the new version to `version.txt` for ease of use in other reports.
 
 ## Required CI Variables
 


### PR DESCRIPTION
Latest feature was missing documentation (I had this locally but forgot to commit for some reason)