### PR TITLE
fix(semantic-release-config): update internal versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "tablecheck-react-system",
 			"version": "0.0.0",
 			"license": "MIT",
 			"dependencies": {
@@ -22,6 +23,7 @@
 				"@rollup/plugin-json": "^4.1.0",
 				"@rollup/plugin-node-resolve": "^13.0.4",
 				"@semantic-release/commit-analyzer": "^8.0.1",
+				"@semantic-release/exec": "^6.0.2",
 				"@semantic-release/release-notes-generator": "^9.0.3",
 				"@turingpointde/cvss.js": "^1.4.6",
 				"@types/jest": "^26.0.24",
@@ -90,7 +92,7 @@
 				"rollup": "^2.55.1",
 				"rollup-plugin-node-externals": "^2.2.0",
 				"rollup-plugin-typescript2": "^0.30.0",
-				"semantic-release-slack-bot": "^2.1.1",
+				"semantic-release-slack-bot": "^3.1.0",
 				"semver": "^7.3.5",
 				"staged-git-files": "^1.2.0",
 				"string-similarity": "^4.0.4",
@@ -5869,6 +5871,33 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
 			"integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg=="
+		},
+		"node_modules/@semantic-release/exec": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/@semantic-release/exec/-/exec-6.0.3.tgz",
+			"integrity": "sha512-bxAq8vLOw76aV89vxxICecEa8jfaWwYITw6X74zzlO0mc/Bgieqx9kBRz9z96pHectiTAtsCwsQcUyLYWnp3VQ==",
+			"dependencies": {
+				"@semantic-release/error": "^3.0.0",
+				"aggregate-error": "^3.0.0",
+				"debug": "^4.0.0",
+				"execa": "^5.0.0",
+				"lodash": "^4.17.4",
+				"parse-json": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=14.17"
+			},
+			"peerDependencies": {
+				"semantic-release": ">=18.0.0"
+			}
+		},
+		"node_modules/@semantic-release/exec/node_modules/@semantic-release/error": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
+			"integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
+			"engines": {
+				"node": ">=14.17"
+			}
 		},
 		"node_modules/@semantic-release/release-notes-generator": {
 			"version": "9.0.3",
@@ -33964,9 +33993,9 @@
 			}
 		},
 		"node_modules/semantic-release-slack-bot": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/semantic-release-slack-bot/-/semantic-release-slack-bot-2.1.1.tgz",
-			"integrity": "sha512-keNqVsZ+Ntm1F8O5yqoX3DmIsH1gK+CDmPhcjLAHTOtmJSul2kRFzEnAac1O8LltF9BQ2wW5OJ3BXcFWXt49aw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/semantic-release-slack-bot/-/semantic-release-slack-bot-3.1.0.tgz",
+			"integrity": "sha512-CqVEIQgmMuFk/WIS8tsmGfc57xe9MR0f7k30afrRyIkag+FvytJ8kfPhkI5MjQO1EKAbD4sQXHILinZWHZxMVg==",
 			"dependencies": {
 				"@semantic-release/error": "^2.2.0",
 				"micromatch": "4.0.2",
@@ -33974,10 +34003,10 @@
 				"slackify-markdown": "^4.3.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=14.7"
 			},
 			"peerDependencies": {
-				"semantic-release": ">=11.0.0 <18.0.0"
+				"semantic-release": ">=11.0.0 <19.0.0"
 			}
 		},
 		"node_modules/semantic-release-slack-bot/node_modules/micromatch": {
@@ -40191,7 +40220,7 @@
 		},
 		"packages/commitlint-config": {
 			"name": "@tablecheck/commitlint-config",
-			"version": "1.0.2",
+			"version": "1.0.3",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -40254,7 +40283,7 @@
 		},
 		"packages/scripts": {
 			"name": "@tablecheck/scripts",
-			"version": "1.8.2",
+			"version": "1.9.0",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -40361,13 +40390,14 @@
 		},
 		"packages/semantic-release-config": {
 			"name": "@tablecheck/semantic-release-config",
-			"version": "2.0.0",
+			"version": "2.1.0",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@semantic-release/commit-analyzer": "^8.0.1",
+				"@semantic-release/exec": "^6.0.2",
 				"@semantic-release/release-notes-generator": "^9.0.3",
-				"semantic-release-slack-bot": "^2.1.1"
+				"semantic-release-slack-bot": "^3.1.0"
 			},
 			"peerDependencies": {
 				"semantic-release": "^17"
@@ -44785,6 +44815,26 @@
 			"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
 			"integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg=="
 		},
+		"@semantic-release/exec": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/@semantic-release/exec/-/exec-6.0.3.tgz",
+			"integrity": "sha512-bxAq8vLOw76aV89vxxICecEa8jfaWwYITw6X74zzlO0mc/Bgieqx9kBRz9z96pHectiTAtsCwsQcUyLYWnp3VQ==",
+			"requires": {
+				"@semantic-release/error": "^3.0.0",
+				"aggregate-error": "^3.0.0",
+				"debug": "^4.0.0",
+				"execa": "^5.0.0",
+				"lodash": "^4.17.4",
+				"parse-json": "^5.0.0"
+			},
+			"dependencies": {
+				"@semantic-release/error": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
+					"integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw=="
+				}
+			}
+		},
 		"@semantic-release/release-notes-generator": {
 			"version": "9.0.3",
 			"resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-9.0.3.tgz",
@@ -46822,8 +46872,9 @@
 			"version": "file:packages/semantic-release-config",
 			"requires": {
 				"@semantic-release/commit-analyzer": "^8.0.1",
+				"@semantic-release/exec": "^6.0.2",
 				"@semantic-release/release-notes-generator": "^9.0.3",
-				"semantic-release-slack-bot": "^2.1.1"
+				"semantic-release-slack-bot": "^3.1.0"
 			}
 		},
 		"@tootallnate/once": {
@@ -66924,9 +66975,9 @@
 			}
 		},
 		"semantic-release-slack-bot": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/semantic-release-slack-bot/-/semantic-release-slack-bot-2.1.1.tgz",
-			"integrity": "sha512-keNqVsZ+Ntm1F8O5yqoX3DmIsH1gK+CDmPhcjLAHTOtmJSul2kRFzEnAac1O8LltF9BQ2wW5OJ3BXcFWXt49aw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/semantic-release-slack-bot/-/semantic-release-slack-bot-3.1.0.tgz",
+			"integrity": "sha512-CqVEIQgmMuFk/WIS8tsmGfc57xe9MR0f7k30afrRyIkag+FvytJ8kfPhkI5MjQO1EKAbD4sQXHILinZWHZxMVg==",
 			"requires": {
 				"@semantic-release/error": "^2.2.0",
 				"micromatch": "4.0.2",

--- a/packages/semantic-release-config/package.json
+++ b/packages/semantic-release-config/package.json
@@ -16,10 +16,10 @@
     "@semantic-release/commit-analyzer": "^8.0.1",
     "@semantic-release/exec": "^6.0.2",
     "@semantic-release/release-notes-generator": "^9.0.3",
-    "semantic-release-slack-bot": "^2.1.1"
+    "semantic-release-slack-bot": "^3.1.0"
   },
   "peerDependencies": {
-    "semantic-release": "^17"
+    "semantic-release": "^18"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Updating with the changes from https://github.com/juliuscc/semantic-release-slack-bot/pull/79
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/semantic-release-config@2.2.0-canary.40.d35a31e29995e48b90f74d7f4e22853b44f6ddc5.0
  # or 
  yarn add @tablecheck/semantic-release-config@2.2.0-canary.40.d35a31e29995e48b90f74d7f4e22853b44f6ddc5.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
