### PR TITLE
feat: add semantic-release config including npm publish

### DIFF
--- a/packages/semantic-release-config/README.md
+++ b/packages/semantic-release-config/README.md
@@ -20,9 +20,18 @@ Setup the configuration file of semantic-release as follows. For more details on
 
 To run a release, simply run `npx semantic-release` (`semantic-release` is a required peer-dependency)
 
-```
+```js
 // release.config.js
 module.exports = {
   extends: '@tablecheck/semantic-release-config'
+};
+```
+
+If your release also needs to publish an npm package, use the following config. Refer to the [@semantic-release/npm](https://github.com/semantic-release/npm) docs for required environment variables and setup.
+
+```js
+// release.config.js
+module.exports = {
+  extends: '@tablecheck/semantic-release-config/with-npm-publish'
 };
 ```

--- a/packages/semantic-release-config/README.stories.mdx
+++ b/packages/semantic-release-config/README.stories.mdx
@@ -22,9 +22,18 @@ Setup the configuration file of semantic-release as follows. For more details on
 
 To run a release, simply run `npx semantic-release` (`semantic-release` is a required peer-dependency)
 
-```
+```js
 // release.config.js
 module.exports = {
   extends: '@tablecheck/semantic-release-config'
+};
+```
+
+If your release also needs to publish an npm package, use the following config. Refer to the [@semantic-release/npm](https://github.com/semantic-release/npm) docs for required environment variables and setup.
+
+```js
+// release.config.js
+module.exports = {
+  extends: '@tablecheck/semantic-release-config/with-npm-publish'
 };
 ```

--- a/packages/semantic-release-config/package.json
+++ b/packages/semantic-release-config/package.json
@@ -10,7 +10,8 @@
   "version": "2.3.0",
   "main": "index.js",
   "files": [
-    "index.js"
+    "with-npm-publish/package.json",
+    "withNpmPublish.js"
   ],
   "dependencies": {
     "@semantic-release/commit-analyzer": "^8.0.1",
@@ -19,7 +20,7 @@
     "semantic-release-slack-bot": "^3.1.0"
   },
   "peerDependencies": {
-    "semantic-release": "^18"
+    "semantic-release": "^18 || ^19"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/semantic-release-config/with-npm-publish/package.json
+++ b/packages/semantic-release-config/with-npm-publish/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "main": "../withNpmPublish.js"
+}

--- a/packages/semantic-release-config/withNpmPublish.js
+++ b/packages/semantic-release-config/withNpmPublish.js
@@ -1,0 +1,6 @@
+const baseConfig = require('./index');
+
+module.exports = {
+  ...baseConfig,
+  plugins: baseConfig.plugins.concat(['@semantic-release/npm'])
+};


### PR DESCRIPTION
Used for publishing to any npm repository as part of the semantic-release step. Currently semantic-release configs don't allow partial extension, so we would need to manually extend the config to use it in our applications.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/semantic-release-config@2.4.0-canary.46.c432086551b83b1afa13b56f00cdda9d58d8dadd.0
  # or 
  yarn add @tablecheck/semantic-release-config@2.4.0-canary.46.c432086551b83b1afa13b56f00cdda9d58d8dadd.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
