### PR TITLE
fix(eslint-plugin): correctly handle jsx fragments

### DIFF
--- a/packages/eslint-config/rules/react.js
+++ b/packages/eslint-config/rules/react.js
@@ -41,6 +41,7 @@ module.exports = {
     { ignoreClassFields: true }
   ],
   'react/no-find-dom-node': 'error',
+  'react/jsx-fragments': 'error',
   'react/jsx-no-useless-fragment': ['error', { allowExpressions: true }],
   '@tablecheck/consistent-react-import': 'error'
 };

--- a/packages/eslint-plugin/__tests__/consistentReactImport.test.js
+++ b/packages/eslint-plugin/__tests__/consistentReactImport.test.js
@@ -1,9 +1,18 @@
-const { RuleTester } = require('eslint');
+const {
+  ESLintUtils: { RuleTester }
+} = require('@typescript-eslint/utils');
 
 const rule = require('../src/consistentReactImport');
 
 const ruleTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2015, sourceType: 'module' }
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true
+    }
+  }
 });
 
 const messageId = 'consistentReactImport';
@@ -48,6 +57,74 @@ const invalidTests = [
     function useHook() {
       const [val, setVal] = ReactCustom.useState(true);
       return ReactCustom.useMemo(() => val, []);
+    }`,
+    errors: [
+      {
+        messageId
+      }
+    ]
+  },
+  {
+    code: `
+    import { Fragment } from 'react';
+    function Component() {
+      return <Fragment>Something</Fragment>;
+    }`,
+    output: `
+    import * as React from 'react';
+    function Component() {
+      return <React.Fragment>Something</React.Fragment>;
+    }`,
+    errors: [
+      {
+        messageId
+      }
+    ]
+  },
+  {
+    code: `
+    import { Fragment as Fr } from 'react';
+    function Component() {
+      return <Fr>Something</Fr>;
+    }`,
+    output: `
+    import * as React from 'react';
+    function Component() {
+      return <React.Fragment>Something</React.Fragment>;
+    }`,
+    errors: [
+      {
+        messageId
+      }
+    ]
+  },
+  {
+    code: `
+    import { Fragment } from 'react';
+    function Component() {
+      return <Fragment key="one">Something</Fragment>;
+    }`,
+    output: `
+    import * as React from 'react';
+    function Component() {
+      return <React.Fragment key="one">Something</React.Fragment>;
+    }`,
+    errors: [
+      {
+        messageId
+      }
+    ]
+  },
+  {
+    code: `
+    import { Fragment } from 'react';
+    function Component() {
+      return <Fragment key="one"><div><>Inner <Fragment>Center</Fragment></> Outer</div></Fragment>;
+    }`,
+    output: `
+    import * as React from 'react';
+    function Component() {
+      return <React.Fragment key="one"><div><>Inner <React.Fragment>Center</React.Fragment></> Outer</div></React.Fragment>;
     }`,
     errors: [
       {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -19,6 +19,9 @@
   "peerDependencies": {
     "eslint": "^8"
   },
+  "devDependencies": {
+    "@typescript-eslint/utils": "5.16.0"
+  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
Fixes #49

Additionally enabled consistent fragment usage.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/eslint-config@1.7.1-canary.50.2051540977.0
  npm install @tablecheck/eslint-plugin@1.2.1-canary.50.2051540977.0
  npm install @tablecheck/scripts@1.11.1-canary.50.2051540977.0
  # or 
  yarn add @tablecheck/eslint-config@1.7.1-canary.50.2051540977.0
  yarn add @tablecheck/eslint-plugin@1.2.1-canary.50.2051540977.0
  yarn add @tablecheck/scripts@1.11.1-canary.50.2051540977.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
