### PR TITLE
fix(scripts): support PUBLIC_PATH in sourcemaps for SSPA children

### DIFF
--- a/packages/scripts/razzle/sspa.js
+++ b/packages/scripts/razzle/sspa.js
@@ -1,6 +1,7 @@
 const { produce } = require('immer');
 const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
 const config = require('config');
+const webpack = require('webpack');
 const baseConfig = require('./spa');
 const paths = require('../config/paths');
 const { getArgv } = require('../scripts/utils/argv');
@@ -20,7 +21,7 @@ const argv = getArgv({
 });
 
 module.exports = baseConfig.extend({
-  modifyWebpackConfig({ webpackConfig }) {
+  modifyWebpackConfig({ webpackConfig, env: { dev } }) {
     return produce((webpackConfigDraft) => {
       webpackConfigDraft.output = webpackConfigDraft.output || {};
       if (!argv.standalone) {
@@ -36,6 +37,15 @@ module.exports = baseConfig.extend({
           }
         })
       );
+      if (!dev) {
+        webpackConfigDraft.devtool = false;
+        webpackConfigDraft.plugins.push(
+          new webpack.SourceMapDevToolPlugin({
+            filename: '[file].map',
+            publicPath: process.env.PUBLIC_PATH
+          })
+        );
+      }
     })(webpackConfig);
   }
 });


### PR DESCRIPTION
An issue that came out of replay.io not being able to match the source maps on production. Reference https://app.replay.io/recording/tablecheck-settings--15d8f820-cc94-492f-aa2b-fcb5d8995343
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/scripts@1.11.2-canary.51.2093968051.0
  # or 
  yarn add @tablecheck/scripts@1.11.2-canary.51.2093968051.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
