### PR TITLE
fix(scripts): eslint and typescript work correctly in cypress files

### DIFF
--- a/packages/scripts/scripts/utils/configureTypescript.js
+++ b/packages/scripts/scripts/utils/configureTypescript.js
@@ -17,6 +17,8 @@ const {
 
 const excludeWithTests = [
   'node_modules',
+  '**/*.cypress.ts',
+  '**/*.cypress.tsx',
   '**/*.test.ts',
   '**/*.test.tsx',
   '**/__tests__/**/*',
@@ -150,7 +152,6 @@ module.exports = {
     }
     if (fs.existsSync(paths.cypress)) {
       eslintRoots.push('cypress');
-      packageConfig.exclude.push('src/**/*.cypress.tsx', 'src/**/*.cypress.ts');
       const compilerPaths = {
         // this let's us import cypress files from an absolute path in our component tests
         '#cypress/*': ['../cypress/*']
@@ -233,7 +234,10 @@ module.exports = {
         files,
         include: eslintRoots,
         compilerOptions: {
-          noEmit: true
+          noEmit: true,
+          types: eslintRoots.include('cypress')
+            ? ['cypress', 'node']
+            : undefined
         }
       },
       true
@@ -268,7 +272,6 @@ module.exports = {
     const runnerConfigPath = path.join(paths.cwd, 'tsconfig.json');
 
     if (fs.existsSync(paths.cypress)) {
-      config.exclude.push('src/**/*.cypress.tsx', 'src/**/*.cypress.ts');
       const compilerPaths = {
         // this let's us import cypress files from an absolute path in our component tests
         '#cypress/*': ['../cypress/*']
@@ -278,11 +281,15 @@ module.exports = {
         path.join(paths.cwd, 'tsconfig.eslint.json'),
         {
           ...config,
-          include: include.concat(systemSettings.additionalRoots || []),
+          include: include.concat(
+            ['cypress'],
+            systemSettings.additionalRoots || []
+          ),
           compilerOptions: {
             ...config.compilerOptions,
             isolatedModules: false,
-            noEmit: true
+            noEmit: true,
+            types: ['cypress', 'node']
           }
         },
         true


### PR DESCRIPTION
Fixes the config options that prevented eslint errors and weird typescript errors in both `src/**/*.cypress.tsx?` files and all files inside the cypress bundle.

This should have only affected usage within IDEs like vscode and not the lint script itself.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/scripts@1.11.2-canary.52.2164645099.0
  # or 
  yarn add @tablecheck/scripts@1.11.2-canary.52.2164645099.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
