### PR TITLE
fix(scripts): compatability with 3rd party jest tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,48 @@ npm ci --legacy-peer-deps
 npm start
 ```
 
+#### Setting up VSCode Jest runner
+
+To use this project with the [VSCode Jest Extension](https://marketplace.visualstudio.com/items?itemName=Orta.vscode-jest) follow the instructions below.
+In your Workspace Settings, setup the folders to be the following;
+
+```json
+  "folders": [
+    {
+      "name": "root",
+      "path": "."
+    },
+    {
+      "name": "@tablecheck/scripts",
+      "path": "./packages/scripts"
+    },
+    {
+      "name": "@tablecheck/codemods",
+      "path": "./packages/codemods"
+    },
+    {
+      "name": "@tablecheck/eslint-plugin",
+      "path": "./packages/eslint-plugin"
+    }
+  ],
+```
+
+In each of the `packages/*` folders mentioned above, create a `.vscode/settings.json` file with the following content;
+
+```json
+{
+  "jest.jestCommandLine": "npm test --"
+}
+```
+
+At the root of this project add a `.vscode/settings.json` file with the following content to disable the top level test.
+
+```json
+{
+  "jest.jestCommandLine": "echo ''"
+}
+```
+
 ## Contributors ✨
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):

--- a/package-lock.json
+++ b/package-lock.json
@@ -116,6 +116,7 @@
 				"@commitlint/cli": "16.2.3",
 				"@commitlint/config-lerna-scopes": "16.2.2",
 				"@storybook/addon-actions": "6.4.19",
+				"@storybook/addon-docs": "6.4.19",
 				"@storybook/addon-essentials": "6.4.19",
 				"@storybook/addon-links": "6.4.19",
 				"@storybook/node-logger": "6.4.19",
@@ -10056,105 +10057,7 @@
 				}
 			}
 		},
-		"node_modules/@storybook/addon-essentials": {
-			"version": "6.4.19",
-			"resolved": "https://registry.npmjs.org/@storybook/addon-essentials/-/addon-essentials-6.4.19.tgz",
-			"integrity": "sha512-vbV8sjepMVEuwhTDBHjO3E6vXluG7RiEeozV1QVuS9lGhjQdvUPdZ9rDNUcP6WHhTdEkS/ffTMaGIy1v8oZd7g==",
-			"dev": true,
-			"dependencies": {
-				"@storybook/addon-actions": "6.4.19",
-				"@storybook/addon-backgrounds": "6.4.19",
-				"@storybook/addon-controls": "6.4.19",
-				"@storybook/addon-docs": "6.4.19",
-				"@storybook/addon-measure": "6.4.19",
-				"@storybook/addon-outline": "6.4.19",
-				"@storybook/addon-toolbars": "6.4.19",
-				"@storybook/addon-viewport": "6.4.19",
-				"@storybook/addons": "6.4.19",
-				"@storybook/api": "6.4.19",
-				"@storybook/node-logger": "6.4.19",
-				"core-js": "^3.8.2",
-				"regenerator-runtime": "^0.13.7",
-				"ts-dedent": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/storybook"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.9.6",
-				"@storybook/vue": "6.4.19",
-				"@storybook/web-components": "6.4.19",
-				"babel-loader": "^8.0.0",
-				"lit-html": "^1.4.1 || ^2.0.0-rc.3",
-				"react": "^16.8.0 || ^17.0.0",
-				"react-dom": "^16.8.0 || ^17.0.0",
-				"webpack": "*"
-			},
-			"peerDependenciesMeta": {
-				"@storybook/vue": {
-					"optional": true
-				},
-				"@storybook/web-components": {
-					"optional": true
-				},
-				"lit-html": {
-					"optional": true
-				},
-				"react": {
-					"optional": true
-				},
-				"react-dom": {
-					"optional": true
-				},
-				"webpack": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@storybook/addon-essentials/node_modules/@jest/transform": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.6.2.tgz",
-			"integrity": "sha512-E9JjhUgNzvuQ+vVAL21vlyfy12gP0GhazGgJC4h6qUt1jSdUXGWJ1wfu/X7Sd8etSgxV4ovT1pb9v5D6QW4XgA==",
-			"dev": true,
-			"dependencies": {
-				"@babel/core": "^7.1.0",
-				"@jest/types": "^26.6.2",
-				"babel-plugin-istanbul": "^6.0.0",
-				"chalk": "^4.0.0",
-				"convert-source-map": "^1.4.0",
-				"fast-json-stable-stringify": "^2.0.0",
-				"graceful-fs": "^4.2.4",
-				"jest-haste-map": "^26.6.2",
-				"jest-regex-util": "^26.0.0",
-				"jest-util": "^26.6.2",
-				"micromatch": "^4.0.2",
-				"pirates": "^4.0.1",
-				"slash": "^3.0.0",
-				"source-map": "^0.6.1",
-				"write-file-atomic": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 10.14.2"
-			}
-		},
-		"node_modules/@storybook/addon-essentials/node_modules/@jest/types": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
-			"integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
-			"dev": true,
-			"dependencies": {
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
-				"@types/node": "*",
-				"@types/yargs": "^15.0.0",
-				"chalk": "^4.0.0"
-			},
-			"engines": {
-				"node": ">= 10.14.2"
-			}
-		},
-		"node_modules/@storybook/addon-essentials/node_modules/@storybook/addon-docs": {
+		"node_modules/@storybook/addon-docs": {
 			"version": "6.4.19",
 			"resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-6.4.19.tgz",
 			"integrity": "sha512-OEPyx/5ZXmZOPqIAWoPjlIP8Q/YfNjAmBosA8tmA8t5KCSiq/vpLcAvQhxqK6n0wk/B8Xp67Z8RpLfXjU8R3tw==",
@@ -10272,7 +10175,49 @@
 				}
 			}
 		},
-		"node_modules/@storybook/addon-essentials/node_modules/@types/yargs": {
+		"node_modules/@storybook/addon-docs/node_modules/@jest/transform": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.6.2.tgz",
+			"integrity": "sha512-E9JjhUgNzvuQ+vVAL21vlyfy12gP0GhazGgJC4h6qUt1jSdUXGWJ1wfu/X7Sd8etSgxV4ovT1pb9v5D6QW4XgA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/core": "^7.1.0",
+				"@jest/types": "^26.6.2",
+				"babel-plugin-istanbul": "^6.0.0",
+				"chalk": "^4.0.0",
+				"convert-source-map": "^1.4.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"graceful-fs": "^4.2.4",
+				"jest-haste-map": "^26.6.2",
+				"jest-regex-util": "^26.0.0",
+				"jest-util": "^26.6.2",
+				"micromatch": "^4.0.2",
+				"pirates": "^4.0.1",
+				"slash": "^3.0.0",
+				"source-map": "^0.6.1",
+				"write-file-atomic": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 10.14.2"
+			}
+		},
+		"node_modules/@storybook/addon-docs/node_modules/@jest/types": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+			"integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/istanbul-lib-coverage": "^2.0.0",
+				"@types/istanbul-reports": "^3.0.0",
+				"@types/node": "*",
+				"@types/yargs": "^15.0.0",
+				"chalk": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 10.14.2"
+			}
+		},
+		"node_modules/@storybook/addon-docs/node_modules/@types/yargs": {
 			"version": "15.0.14",
 			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
 			"integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
@@ -10281,7 +10226,7 @@
 				"@types/yargs-parser": "*"
 			}
 		},
-		"node_modules/@storybook/addon-essentials/node_modules/acorn": {
+		"node_modules/@storybook/addon-docs/node_modules/acorn": {
 			"version": "7.4.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
 			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
@@ -10293,7 +10238,7 @@
 				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/@storybook/addon-essentials/node_modules/jest-haste-map": {
+		"node_modules/@storybook/addon-docs/node_modules/jest-haste-map": {
 			"version": "26.6.2",
 			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.2.tgz",
 			"integrity": "sha512-easWIJXIw71B2RdR8kgqpjQrbMRWQBgiBwXYEhtGUTaX+doCjBheluShdDMeR8IMfJiTqH4+zfhtg29apJf/8w==",
@@ -10320,7 +10265,7 @@
 				"fsevents": "^2.1.2"
 			}
 		},
-		"node_modules/@storybook/addon-essentials/node_modules/jest-regex-util": {
+		"node_modules/@storybook/addon-docs/node_modules/jest-regex-util": {
 			"version": "26.0.0",
 			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-26.0.0.tgz",
 			"integrity": "sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==",
@@ -10329,7 +10274,7 @@
 				"node": ">= 10.14.2"
 			}
 		},
-		"node_modules/@storybook/addon-essentials/node_modules/jest-serializer": {
+		"node_modules/@storybook/addon-docs/node_modules/jest-serializer": {
 			"version": "26.6.2",
 			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.6.2.tgz",
 			"integrity": "sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==",
@@ -10342,7 +10287,7 @@
 				"node": ">= 10.14.2"
 			}
 		},
-		"node_modules/@storybook/addon-essentials/node_modules/jest-util": {
+		"node_modules/@storybook/addon-docs/node_modules/jest-util": {
 			"version": "26.6.2",
 			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
 			"integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
@@ -10359,7 +10304,7 @@
 				"node": ">= 10.14.2"
 			}
 		},
-		"node_modules/@storybook/addon-essentials/node_modules/jest-worker": {
+		"node_modules/@storybook/addon-docs/node_modules/jest-worker": {
 			"version": "26.6.2",
 			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
 			"integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
@@ -10373,7 +10318,7 @@
 				"node": ">= 10.13.0"
 			}
 		},
-		"node_modules/@storybook/addon-essentials/node_modules/prettier": {
+		"node_modules/@storybook/addon-docs/node_modules/prettier": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
 			"integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
@@ -10385,13 +10330,69 @@
 				"node": ">=10.13.0"
 			}
 		},
-		"node_modules/@storybook/addon-essentials/node_modules/source-map": {
+		"node_modules/@storybook/addon-docs/node_modules/source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@storybook/addon-essentials": {
+			"version": "6.4.19",
+			"resolved": "https://registry.npmjs.org/@storybook/addon-essentials/-/addon-essentials-6.4.19.tgz",
+			"integrity": "sha512-vbV8sjepMVEuwhTDBHjO3E6vXluG7RiEeozV1QVuS9lGhjQdvUPdZ9rDNUcP6WHhTdEkS/ffTMaGIy1v8oZd7g==",
+			"dev": true,
+			"dependencies": {
+				"@storybook/addon-actions": "6.4.19",
+				"@storybook/addon-backgrounds": "6.4.19",
+				"@storybook/addon-controls": "6.4.19",
+				"@storybook/addon-docs": "6.4.19",
+				"@storybook/addon-measure": "6.4.19",
+				"@storybook/addon-outline": "6.4.19",
+				"@storybook/addon-toolbars": "6.4.19",
+				"@storybook/addon-viewport": "6.4.19",
+				"@storybook/addons": "6.4.19",
+				"@storybook/api": "6.4.19",
+				"@storybook/node-logger": "6.4.19",
+				"core-js": "^3.8.2",
+				"regenerator-runtime": "^0.13.7",
+				"ts-dedent": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/storybook"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.9.6",
+				"@storybook/vue": "6.4.19",
+				"@storybook/web-components": "6.4.19",
+				"babel-loader": "^8.0.0",
+				"lit-html": "^1.4.1 || ^2.0.0-rc.3",
+				"react": "^16.8.0 || ^17.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0",
+				"webpack": "*"
+			},
+			"peerDependenciesMeta": {
+				"@storybook/vue": {
+					"optional": true
+				},
+				"@storybook/web-components": {
+					"optional": true
+				},
+				"lit-html": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"react-dom": {
+					"optional": true
+				},
+				"webpack": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@storybook/addon-links": {
@@ -51964,26 +51965,58 @@
 				"ts-dedent": "^2.0.0"
 			}
 		},
-		"@storybook/addon-essentials": {
+		"@storybook/addon-docs": {
 			"version": "6.4.19",
-			"resolved": "https://registry.npmjs.org/@storybook/addon-essentials/-/addon-essentials-6.4.19.tgz",
-			"integrity": "sha512-vbV8sjepMVEuwhTDBHjO3E6vXluG7RiEeozV1QVuS9lGhjQdvUPdZ9rDNUcP6WHhTdEkS/ffTMaGIy1v8oZd7g==",
+			"resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-6.4.19.tgz",
+			"integrity": "sha512-OEPyx/5ZXmZOPqIAWoPjlIP8Q/YfNjAmBosA8tmA8t5KCSiq/vpLcAvQhxqK6n0wk/B8Xp67Z8RpLfXjU8R3tw==",
 			"dev": true,
 			"requires": {
-				"@storybook/addon-actions": "6.4.19",
-				"@storybook/addon-backgrounds": "6.4.19",
-				"@storybook/addon-controls": "6.4.19",
-				"@storybook/addon-docs": "6.4.19",
-				"@storybook/addon-measure": "6.4.19",
-				"@storybook/addon-outline": "6.4.19",
-				"@storybook/addon-toolbars": "6.4.19",
-				"@storybook/addon-viewport": "6.4.19",
+				"@babel/core": "^7.12.10",
+				"@babel/generator": "^7.12.11",
+				"@babel/parser": "^7.12.11",
+				"@babel/plugin-transform-react-jsx": "^7.12.12",
+				"@babel/preset-env": "^7.12.11",
+				"@jest/transform": "^26.6.2",
+				"@mdx-js/loader": "^1.6.22",
+				"@mdx-js/mdx": "^1.6.22",
+				"@mdx-js/react": "^1.6.22",
 				"@storybook/addons": "6.4.19",
 				"@storybook/api": "6.4.19",
+				"@storybook/builder-webpack4": "6.4.19",
+				"@storybook/client-logger": "6.4.19",
+				"@storybook/components": "6.4.19",
+				"@storybook/core": "6.4.19",
+				"@storybook/core-events": "6.4.19",
+				"@storybook/csf": "0.0.2--canary.87bc651.0",
+				"@storybook/csf-tools": "6.4.19",
 				"@storybook/node-logger": "6.4.19",
+				"@storybook/postinstall": "6.4.19",
+				"@storybook/preview-web": "6.4.19",
+				"@storybook/source-loader": "6.4.19",
+				"@storybook/store": "6.4.19",
+				"@storybook/theming": "6.4.19",
+				"acorn": "^7.4.1",
+				"acorn-jsx": "^5.3.1",
+				"acorn-walk": "^7.2.0",
 				"core-js": "^3.8.2",
+				"doctrine": "^3.0.0",
+				"escodegen": "^2.0.0",
+				"fast-deep-equal": "^3.1.3",
+				"global": "^4.4.0",
+				"html-tags": "^3.1.0",
+				"js-string-escape": "^1.0.1",
+				"loader-utils": "^2.0.0",
+				"lodash": "^4.17.21",
+				"nanoid": "^3.1.23",
+				"p-limit": "^3.1.0",
+				"prettier": ">=2.2.1 <=2.3.0",
+				"prop-types": "^15.7.2",
+				"react-element-to-jsx-string": "^14.3.4",
 				"regenerator-runtime": "^0.13.7",
-				"ts-dedent": "^2.0.0"
+				"remark-external-links": "^8.0.0",
+				"remark-slug": "^6.0.0",
+				"ts-dedent": "^2.0.0",
+				"util-deprecate": "^1.0.2"
 			},
 			"dependencies": {
 				"@jest/transform": {
@@ -52020,60 +52053,6 @@
 						"@types/node": "*",
 						"@types/yargs": "^15.0.0",
 						"chalk": "^4.0.0"
-					}
-				},
-				"@storybook/addon-docs": {
-					"version": "6.4.19",
-					"resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-6.4.19.tgz",
-					"integrity": "sha512-OEPyx/5ZXmZOPqIAWoPjlIP8Q/YfNjAmBosA8tmA8t5KCSiq/vpLcAvQhxqK6n0wk/B8Xp67Z8RpLfXjU8R3tw==",
-					"dev": true,
-					"requires": {
-						"@babel/core": "^7.12.10",
-						"@babel/generator": "^7.12.11",
-						"@babel/parser": "^7.12.11",
-						"@babel/plugin-transform-react-jsx": "^7.12.12",
-						"@babel/preset-env": "^7.12.11",
-						"@jest/transform": "^26.6.2",
-						"@mdx-js/loader": "^1.6.22",
-						"@mdx-js/mdx": "^1.6.22",
-						"@mdx-js/react": "^1.6.22",
-						"@storybook/addons": "6.4.19",
-						"@storybook/api": "6.4.19",
-						"@storybook/builder-webpack4": "6.4.19",
-						"@storybook/client-logger": "6.4.19",
-						"@storybook/components": "6.4.19",
-						"@storybook/core": "6.4.19",
-						"@storybook/core-events": "6.4.19",
-						"@storybook/csf": "0.0.2--canary.87bc651.0",
-						"@storybook/csf-tools": "6.4.19",
-						"@storybook/node-logger": "6.4.19",
-						"@storybook/postinstall": "6.4.19",
-						"@storybook/preview-web": "6.4.19",
-						"@storybook/source-loader": "6.4.19",
-						"@storybook/store": "6.4.19",
-						"@storybook/theming": "6.4.19",
-						"acorn": "^7.4.1",
-						"acorn-jsx": "^5.3.1",
-						"acorn-walk": "^7.2.0",
-						"core-js": "^3.8.2",
-						"doctrine": "^3.0.0",
-						"escodegen": "^2.0.0",
-						"fast-deep-equal": "^3.1.3",
-						"global": "^4.4.0",
-						"html-tags": "^3.1.0",
-						"js-string-escape": "^1.0.1",
-						"loader-utils": "^2.0.0",
-						"lodash": "^4.17.21",
-						"nanoid": "^3.1.23",
-						"p-limit": "^3.1.0",
-						"prettier": ">=2.2.1 <=2.3.0",
-						"prop-types": "^15.7.2",
-						"react-element-to-jsx-string": "^14.3.4",
-						"regenerator-runtime": "^0.13.7",
-						"remark-external-links": "^8.0.0",
-						"remark-slug": "^6.0.0",
-						"ts-dedent": "^2.0.0",
-						"util-deprecate": "^1.0.2"
 					}
 				},
 				"@types/yargs": {
@@ -52166,6 +52145,28 @@
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				}
+			}
+		},
+		"@storybook/addon-essentials": {
+			"version": "6.4.19",
+			"resolved": "https://registry.npmjs.org/@storybook/addon-essentials/-/addon-essentials-6.4.19.tgz",
+			"integrity": "sha512-vbV8sjepMVEuwhTDBHjO3E6vXluG7RiEeozV1QVuS9lGhjQdvUPdZ9rDNUcP6WHhTdEkS/ffTMaGIy1v8oZd7g==",
+			"dev": true,
+			"requires": {
+				"@storybook/addon-actions": "6.4.19",
+				"@storybook/addon-backgrounds": "6.4.19",
+				"@storybook/addon-controls": "6.4.19",
+				"@storybook/addon-docs": "6.4.19",
+				"@storybook/addon-measure": "6.4.19",
+				"@storybook/addon-outline": "6.4.19",
+				"@storybook/addon-toolbars": "6.4.19",
+				"@storybook/addon-viewport": "6.4.19",
+				"@storybook/addons": "6.4.19",
+				"@storybook/api": "6.4.19",
+				"@storybook/node-logger": "6.4.19",
+				"core-js": "^3.8.2",
+				"regenerator-runtime": "^0.13.7",
+				"ts-dedent": "^2.0.0"
 			}
 		},
 		"@storybook/addon-links": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@commitlint/cli": "16.2.3",
     "@commitlint/config-lerna-scopes": "16.2.2",
     "@storybook/addon-actions": "6.4.19",
+    "@storybook/addon-docs": "6.4.19",
     "@storybook/addon-essentials": "6.4.19",
     "@storybook/addon-links": "6.4.19",
     "@storybook/node-logger": "6.4.19",

--- a/packages/scripts/scripts/test.js
+++ b/packages/scripts/scripts/test.js
@@ -32,6 +32,7 @@ if (process.env.SKIP_PREFLIGHT_CHECK !== 'true') {
 (async () => {
   const argv = getArgv({
     boolean: ['coverage', 'watchAll', 'watch'],
+    string: ['outputFile'],
     default: {
       coverage: false,
       watchAll: false,
@@ -40,7 +41,7 @@ if (process.env.SKIP_PREFLIGHT_CHECK !== 'true') {
   });
 
   // Watch unless on CI, in coverage mode, or explicitly running all tests
-  if (!process.env.CI && !argv.coverage && !argv.watchAll) {
+  if (!process.env.CI && !argv.outputFile && !argv.coverage && !argv.watchAll) {
     argv.watch = true;
   }
 
@@ -77,9 +78,9 @@ if (process.env.SKIP_PREFLIGHT_CHECK !== 'true') {
 
   const { _args: args } = argv;
 
-  ['watch', 'coverage', 'watchAll'].forEach((key) => {
+  ['watch', 'coverage', 'watchAll', 'outputFile'].forEach((key) => {
     if (argv[key]) {
-      args.push(`--${key}`);
+      args.push(`--${key}${argv[key] ? `=${argv[key]}` : ''}`);
     }
   });
 

--- a/packages/scripts/scripts/test.stories.mdx
+++ b/packages/scripts/scripts/test.stories.mdx
@@ -37,3 +37,10 @@ Or in GitHub actions by using the following step definitions.
   with:
     files: junit/**/*.xml
 ```
+
+### Integration with IDE extensions
+
+This command has been tested with the following extensions;
+
+- [VSCode Jest](https://marketplace.visualstudio.com/items?itemName=Orta.vscode-jest)
+  - `jest.jestCommandLine` value should be `npx tablecheck-scripts test --env=jsdom`

--- a/packages/scripts/scripts/utils/argv.js
+++ b/packages/scripts/scripts/utils/argv.js
@@ -119,15 +119,15 @@ function getArgv(customArgs) {
     verbose: false
   };
   const unknownArgs = [];
-  args.unknown = args.unknown || ((arg) => unknownArgs.push(arg) || true);
+  args.unknown = args.unknown || ((arg) => unknownArgs.push(arg) && false);
   const argv = minimist(process.argv.slice(2), args);
   if (shouldIgnorePackageArg) {
     argv.package = '*';
   }
+  argv._args = unknownArgs;
   if (argv.verbose) {
     console.log(chalk.gray(`argv:\n${JSON.stringify(argv, undefined, 2)}`));
   }
-  argv._args = unknownArgs;
   return argv;
 }
 


### PR DESCRIPTION
Fixing some bugs and issues arising from using https://marketplace.visualstudio.com/items?itemName=Orta.vscode-jest

Fixes the storybook build which was missing a plugin dependency
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/scripts@1.12.0-canary.55.2231386425.0
  # or 
  yarn add @tablecheck/scripts@1.12.0-canary.55.2231386425.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
