### PR TITLE
feat(scripts): added jest-watch-typeahead to for better development e…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,7 @@
 				"jest-enzyme": "^7.1.2",
 				"jest-junit": "^13.0.0",
 				"jest-transform-graphql": "^2.1.0",
+				"jest-watch-typeahead": "^1.1.0",
 				"jscodeshift": "^0.13.1",
 				"mini-css-extract-plugin": "^2.6.0",
 				"minimatch": "^5.0.1",
@@ -3380,6 +3381,17 @@
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@jest/schemas": {
+			"version": "28.0.2",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-28.0.2.tgz",
+			"integrity": "sha512-YVDJZjd4izeTDkij00vHHAymNXQ6WWsdChFRK86qck6Jpr3DCL5W3Is3vslviRlP+bLuMYRLbdp98amMvqudhA==",
+			"dependencies": {
+				"@sinclair/typebox": "^0.23.3"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
 			}
 		},
 		"node_modules/@jest/source-map": {
@@ -9916,6 +9928,11 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/@sinclair/typebox": {
+			"version": "0.23.4",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.23.4.tgz",
+			"integrity": "sha512-0/WqSvpVbCBAV1yPeko7eAczKbs78dNVAaX14quVlwOb2wxfKuXCx91h4NrEfkYK9zEnyVSW4JVI/trP3iS+Qg=="
 		},
 		"node_modules/@sindresorhus/is": {
 			"version": "0.14.0",
@@ -26770,6 +26787,280 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/jest-watch-typeahead": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/jest-watch-typeahead/-/jest-watch-typeahead-1.1.0.tgz",
+			"integrity": "sha512-Va5nLSJTN7YFtC2jd+7wsoe1pNe5K4ShLux/E5iHEwlB9AxaxmggY7to9KUqKojhaJw3aXqt5WAb4jGPOolpEw==",
+			"dependencies": {
+				"ansi-escapes": "^4.3.1",
+				"chalk": "^4.0.0",
+				"jest-regex-util": "^28.0.0",
+				"jest-watcher": "^28.0.0",
+				"slash": "^4.0.0",
+				"string-length": "^5.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"peerDependencies": {
+				"jest": "^27.0.0 || ^28.0.0"
+			}
+		},
+		"node_modules/jest-watch-typeahead/node_modules/@jest/console": {
+			"version": "28.0.2",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-28.0.2.tgz",
+			"integrity": "sha512-tiRpnMeeyQuuzgL5UNSeiqMwF8UOWPbAE5rzcu/1zyq4oPG2Ox6xm4YCOruwbp10F8odWc+XwVxTyGzMSLMqxA==",
+			"dependencies": {
+				"@jest/types": "^28.0.2",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"jest-message-util": "^28.0.2",
+				"jest-util": "^28.0.2",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+			}
+		},
+		"node_modules/jest-watch-typeahead/node_modules/@jest/console/node_modules/slash": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-watch-typeahead/node_modules/@jest/test-result": {
+			"version": "28.0.2",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-28.0.2.tgz",
+			"integrity": "sha512-4EUqgjq9VzyUiVTvZfI9IRJD6t3NYBNP4f+Eq8Zr93+hkJ0RrGU4OBTw8tfNzidKX+bmuYzn8FxqpxOPIGGCMA==",
+			"dependencies": {
+				"@jest/console": "^28.0.2",
+				"@jest/types": "^28.0.2",
+				"@types/istanbul-lib-coverage": "^2.0.0",
+				"collect-v8-coverage": "^1.0.0"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+			}
+		},
+		"node_modules/jest-watch-typeahead/node_modules/@jest/types": {
+			"version": "28.0.2",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-28.0.2.tgz",
+			"integrity": "sha512-hi3jUdm9iht7I2yrV5C4s3ucCJHUP8Eh3W6rQ1s4n/Qw9rQgsda4eqCt+r3BKRi7klVmZfQlMx1nGlzNMP2d8A==",
+			"dependencies": {
+				"@jest/schemas": "^28.0.2",
+				"@types/istanbul-lib-coverage": "^2.0.0",
+				"@types/istanbul-reports": "^3.0.0",
+				"@types/node": "*",
+				"@types/yargs": "^17.0.8",
+				"chalk": "^4.0.0"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+			}
+		},
+		"node_modules/jest-watch-typeahead/node_modules/@types/yargs": {
+			"version": "17.0.10",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.10.tgz",
+			"integrity": "sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==",
+			"dependencies": {
+				"@types/yargs-parser": "*"
+			}
+		},
+		"node_modules/jest-watch-typeahead/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/jest-watch-typeahead/node_modules/emittery": {
+			"version": "0.10.2",
+			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.10.2.tgz",
+			"integrity": "sha512-aITqOwnLanpHLNXZJENbOgjUBeHocD+xsSJmNrjovKBW5HbSpW3d1pEls7GFQPUWXiwG9+0P4GtHfEqC/4M0Iw==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/emittery?sponsor=1"
+			}
+		},
+		"node_modules/jest-watch-typeahead/node_modules/jest-message-util": {
+			"version": "28.0.2",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-28.0.2.tgz",
+			"integrity": "sha512-knK7XyojvwYh1XiF2wmVdskgM/uN11KsjcEWWHfnMZNEdwXCrqB4sCBO94F4cfiAwCS8WFV6CDixDwPlMh/wdA==",
+			"dependencies": {
+				"@babel/code-frame": "^7.12.13",
+				"@jest/types": "^28.0.2",
+				"@types/stack-utils": "^2.0.0",
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.9",
+				"micromatch": "^4.0.4",
+				"pretty-format": "^28.0.2",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.3"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+			}
+		},
+		"node_modules/jest-watch-typeahead/node_modules/jest-message-util/node_modules/slash": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-watch-typeahead/node_modules/jest-regex-util": {
+			"version": "28.0.2",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-28.0.2.tgz",
+			"integrity": "sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==",
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+			}
+		},
+		"node_modules/jest-watch-typeahead/node_modules/jest-util": {
+			"version": "28.0.2",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.0.2.tgz",
+			"integrity": "sha512-EVdpIRCC8lzqhp9A0u0aAKlsFIzufK6xKxNK7awsnebTdOP4hpyQW5o6Ox2qPl8gbeUKYF+POLyItaND53kpGA==",
+			"dependencies": {
+				"@jest/types": "^28.0.2",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"graceful-fs": "^4.2.9",
+				"picomatch": "^2.2.3"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+			}
+		},
+		"node_modules/jest-watch-typeahead/node_modules/jest-watcher": {
+			"version": "28.0.2",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-28.0.2.tgz",
+			"integrity": "sha512-uIVJLpQ/5VTGQWBiBatHsi7jrCqHjHl0e0dFHMWzwuIfUbdW/muk0DtSr0fteY2T7QTFylv+7a5Rm8sBKrE12Q==",
+			"dependencies": {
+				"@jest/test-result": "^28.0.2",
+				"@jest/types": "^28.0.2",
+				"@types/node": "*",
+				"ansi-escapes": "^4.2.1",
+				"chalk": "^4.0.0",
+				"emittery": "^0.10.2",
+				"jest-util": "^28.0.2",
+				"string-length": "^4.0.1"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+			}
+		},
+		"node_modules/jest-watch-typeahead/node_modules/jest-watcher/node_modules/string-length": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+			"integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+			"dependencies": {
+				"char-regex": "^1.0.2",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/jest-watch-typeahead/node_modules/jest-watcher/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-watch-typeahead/node_modules/pretty-format": {
+			"version": "28.0.2",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.0.2.tgz",
+			"integrity": "sha512-UmGZ1IERwS3yY35LDMTaBUYI1w4udZDdJGGT/DqQeKG9ZLDn7/K2Jf/JtYSRiHCCKMHvUA+zsEGSmHdpaVp1yw==",
+			"dependencies": {
+				"@jest/schemas": "^28.0.2",
+				"ansi-regex": "^5.0.1",
+				"ansi-styles": "^5.0.0",
+				"react-is": "^18.0.0"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+			}
+		},
+		"node_modules/jest-watch-typeahead/node_modules/react-is": {
+			"version": "18.1.0",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
+			"integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg=="
+		},
+		"node_modules/jest-watch-typeahead/node_modules/slash": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+			"integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/jest-watch-typeahead/node_modules/string-length": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-5.0.1.tgz",
+			"integrity": "sha512-9Ep08KAMUn0OadnVaBuRdE2l615CQ508kr0XMadjClfYpdCyvrbFp6Taebo8yyxokQ4viUd/xPPUA4FGgUa0ow==",
+			"dependencies": {
+				"char-regex": "^2.0.0",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/jest-watch-typeahead/node_modules/string-length/node_modules/char-regex": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-2.0.1.tgz",
+			"integrity": "sha512-oSvEeo6ZUD7NepqAat3RqoucZ5SeqLJgOvVIwkafu6IP3V0pO38s/ypdVUmDDK6qIIHNlYHJAKX9E7R7HoKElw==",
+			"engines": {
+				"node": ">=12.20"
+			}
+		},
+		"node_modules/jest-watch-typeahead/node_modules/strip-ansi": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+			"integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/jest-watch-typeahead/node_modules/strip-ansi/node_modules/ansi-regex": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
 		"node_modules/jest-watcher": {
 			"version": "27.5.1",
 			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.5.1.tgz",
@@ -29937,6 +30228,18 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/normalize-url": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/npm-bundled": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz",
@@ -31209,18 +31512,6 @@
 				"normalize-url": "^6.1.0",
 				"parse-path": "^4.0.0",
 				"protocols": "^1.4.0"
-			}
-		},
-		"node_modules/parse-url/node_modules/normalize-url": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/parse5": {
@@ -43651,7 +43942,7 @@
 		},
 		"packages/scripts": {
 			"name": "@tablecheck/scripts",
-			"version": "1.11.2",
+			"version": "1.11.3",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -43701,6 +43992,7 @@
 				"jest-enzyme": "^7.1.2",
 				"jest-junit": "^13.0.0",
 				"jest-transform-graphql": "^2.1.0",
+				"jest-watch-typeahead": "^1.1.0",
 				"jscodeshift": "^0.13.1",
 				"lint-staged": "^11.2.6",
 				"lodash": "^4.17.21",
@@ -46182,6 +46474,14 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
+			}
+		},
+		"@jest/schemas": {
+			"version": "28.0.2",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-28.0.2.tgz",
+			"integrity": "sha512-YVDJZjd4izeTDkij00vHHAymNXQ6WWsdChFRK86qck6Jpr3DCL5W3Is3vslviRlP+bLuMYRLbdp98amMvqudhA==",
+			"requires": {
+				"@sinclair/typebox": "^0.23.3"
 			}
 		},
 		"@jest/source-map": {
@@ -51876,6 +52176,11 @@
 				}
 			}
 		},
+		"@sinclair/typebox": {
+			"version": "0.23.4",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.23.4.tgz",
+			"integrity": "sha512-0/WqSvpVbCBAV1yPeko7eAczKbs78dNVAaX14quVlwOb2wxfKuXCx91h4NrEfkYK9zEnyVSW4JVI/trP3iS+Qg=="
+		},
 		"@sindresorhus/is": {
 			"version": "0.14.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -53816,6 +54121,7 @@
 				"jest-enzyme": "^7.1.2",
 				"jest-junit": "^13.0.0",
 				"jest-transform-graphql": "^2.1.0",
+				"jest-watch-typeahead": "^1.1.0",
 				"jscodeshift": "^0.13.1",
 				"lint-staged": "^11.2.6",
 				"lodash": "^4.17.21",
@@ -64982,6 +65288,211 @@
 				}
 			}
 		},
+		"jest-watch-typeahead": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/jest-watch-typeahead/-/jest-watch-typeahead-1.1.0.tgz",
+			"integrity": "sha512-Va5nLSJTN7YFtC2jd+7wsoe1pNe5K4ShLux/E5iHEwlB9AxaxmggY7to9KUqKojhaJw3aXqt5WAb4jGPOolpEw==",
+			"requires": {
+				"ansi-escapes": "^4.3.1",
+				"chalk": "^4.0.0",
+				"jest-regex-util": "^28.0.0",
+				"jest-watcher": "^28.0.0",
+				"slash": "^4.0.0",
+				"string-length": "^5.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"dependencies": {
+				"@jest/console": {
+					"version": "28.0.2",
+					"resolved": "https://registry.npmjs.org/@jest/console/-/console-28.0.2.tgz",
+					"integrity": "sha512-tiRpnMeeyQuuzgL5UNSeiqMwF8UOWPbAE5rzcu/1zyq4oPG2Ox6xm4YCOruwbp10F8odWc+XwVxTyGzMSLMqxA==",
+					"requires": {
+						"@jest/types": "^28.0.2",
+						"@types/node": "*",
+						"chalk": "^4.0.0",
+						"jest-message-util": "^28.0.2",
+						"jest-util": "^28.0.2",
+						"slash": "^3.0.0"
+					},
+					"dependencies": {
+						"slash": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+							"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+						}
+					}
+				},
+				"@jest/test-result": {
+					"version": "28.0.2",
+					"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-28.0.2.tgz",
+					"integrity": "sha512-4EUqgjq9VzyUiVTvZfI9IRJD6t3NYBNP4f+Eq8Zr93+hkJ0RrGU4OBTw8tfNzidKX+bmuYzn8FxqpxOPIGGCMA==",
+					"requires": {
+						"@jest/console": "^28.0.2",
+						"@jest/types": "^28.0.2",
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"collect-v8-coverage": "^1.0.0"
+					}
+				},
+				"@jest/types": {
+					"version": "28.0.2",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-28.0.2.tgz",
+					"integrity": "sha512-hi3jUdm9iht7I2yrV5C4s3ucCJHUP8Eh3W6rQ1s4n/Qw9rQgsda4eqCt+r3BKRi7klVmZfQlMx1nGlzNMP2d8A==",
+					"requires": {
+						"@jest/schemas": "^28.0.2",
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^17.0.8",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/yargs": {
+					"version": "17.0.10",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.10.tgz",
+					"integrity": "sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==",
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+					"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="
+				},
+				"emittery": {
+					"version": "0.10.2",
+					"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.10.2.tgz",
+					"integrity": "sha512-aITqOwnLanpHLNXZJENbOgjUBeHocD+xsSJmNrjovKBW5HbSpW3d1pEls7GFQPUWXiwG9+0P4GtHfEqC/4M0Iw=="
+				},
+				"jest-message-util": {
+					"version": "28.0.2",
+					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-28.0.2.tgz",
+					"integrity": "sha512-knK7XyojvwYh1XiF2wmVdskgM/uN11KsjcEWWHfnMZNEdwXCrqB4sCBO94F4cfiAwCS8WFV6CDixDwPlMh/wdA==",
+					"requires": {
+						"@babel/code-frame": "^7.12.13",
+						"@jest/types": "^28.0.2",
+						"@types/stack-utils": "^2.0.0",
+						"chalk": "^4.0.0",
+						"graceful-fs": "^4.2.9",
+						"micromatch": "^4.0.4",
+						"pretty-format": "^28.0.2",
+						"slash": "^3.0.0",
+						"stack-utils": "^2.0.3"
+					},
+					"dependencies": {
+						"slash": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+							"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+						}
+					}
+				},
+				"jest-regex-util": {
+					"version": "28.0.2",
+					"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-28.0.2.tgz",
+					"integrity": "sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw=="
+				},
+				"jest-util": {
+					"version": "28.0.2",
+					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.0.2.tgz",
+					"integrity": "sha512-EVdpIRCC8lzqhp9A0u0aAKlsFIzufK6xKxNK7awsnebTdOP4hpyQW5o6Ox2qPl8gbeUKYF+POLyItaND53kpGA==",
+					"requires": {
+						"@jest/types": "^28.0.2",
+						"@types/node": "*",
+						"chalk": "^4.0.0",
+						"ci-info": "^3.2.0",
+						"graceful-fs": "^4.2.9",
+						"picomatch": "^2.2.3"
+					}
+				},
+				"jest-watcher": {
+					"version": "28.0.2",
+					"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-28.0.2.tgz",
+					"integrity": "sha512-uIVJLpQ/5VTGQWBiBatHsi7jrCqHjHl0e0dFHMWzwuIfUbdW/muk0DtSr0fteY2T7QTFylv+7a5Rm8sBKrE12Q==",
+					"requires": {
+						"@jest/test-result": "^28.0.2",
+						"@jest/types": "^28.0.2",
+						"@types/node": "*",
+						"ansi-escapes": "^4.2.1",
+						"chalk": "^4.0.0",
+						"emittery": "^0.10.2",
+						"jest-util": "^28.0.2",
+						"string-length": "^4.0.1"
+					},
+					"dependencies": {
+						"string-length": {
+							"version": "4.0.2",
+							"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+							"integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+							"requires": {
+								"char-regex": "^1.0.2",
+								"strip-ansi": "^6.0.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "6.0.1",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+							"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+							"requires": {
+								"ansi-regex": "^5.0.1"
+							}
+						}
+					}
+				},
+				"pretty-format": {
+					"version": "28.0.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.0.2.tgz",
+					"integrity": "sha512-UmGZ1IERwS3yY35LDMTaBUYI1w4udZDdJGGT/DqQeKG9ZLDn7/K2Jf/JtYSRiHCCKMHvUA+zsEGSmHdpaVp1yw==",
+					"requires": {
+						"@jest/schemas": "^28.0.2",
+						"ansi-regex": "^5.0.1",
+						"ansi-styles": "^5.0.0",
+						"react-is": "^18.0.0"
+					}
+				},
+				"react-is": {
+					"version": "18.1.0",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
+					"integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg=="
+				},
+				"slash": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+					"integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew=="
+				},
+				"string-length": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/string-length/-/string-length-5.0.1.tgz",
+					"integrity": "sha512-9Ep08KAMUn0OadnVaBuRdE2l615CQ508kr0XMadjClfYpdCyvrbFp6Taebo8yyxokQ4viUd/xPPUA4FGgUa0ow==",
+					"requires": {
+						"char-regex": "^2.0.0",
+						"strip-ansi": "^7.0.1"
+					},
+					"dependencies": {
+						"char-regex": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-2.0.1.tgz",
+							"integrity": "sha512-oSvEeo6ZUD7NepqAat3RqoucZ5SeqLJgOvVIwkafu6IP3V0pO38s/ypdVUmDDK6qIIHNlYHJAKX9E7R7HoKElw=="
+						}
+					}
+				},
+				"strip-ansi": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+					"integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+					"requires": {
+						"ansi-regex": "^6.0.1"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "6.0.1",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+							"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
+						}
+					}
+				}
+			}
+		},
 		"jest-watcher": {
 			"version": "27.5.1",
 			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.5.1.tgz",
@@ -67528,6 +68039,12 @@
 			"integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
 			"dev": true
 		},
+		"normalize-url": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+			"dev": true
+		},
 		"npm-bundled": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz",
@@ -68505,14 +69022,6 @@
 				"normalize-url": "^6.1.0",
 				"parse-path": "^4.0.0",
 				"protocols": "^1.4.0"
-			},
-			"dependencies": {
-				"normalize-url": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-					"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
-					"dev": true
-				}
 			}
 		},
 		"parse5": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -86,6 +86,7 @@
     "jest-enzyme": "^7.1.2",
     "jest-junit": "^13.0.0",
     "jest-transform-graphql": "^2.1.0",
+    "jest-watch-typeahead": "^1.1.0",
     "jscodeshift": "^0.13.1",
     "lint-staged": "^11.2.6",
     "lodash": "^4.17.21",

--- a/packages/scripts/scripts/utils/createJestConfig.js
+++ b/packages/scripts/scripts/utils/createJestConfig.js
@@ -32,6 +32,10 @@ module.exports = (resolve, rootDir, srcRoots, moduleDirectories) => {
       '**/__tests__/*.{ts,tsx,js,jsx}',
       '**/?(*.)(spec|test).{ts,tsx,js,jsx}'
     ],
+    watchPlugins: [
+      'jest-watch-typeahead/filename',
+      'jest-watch-typeahead/testname'
+    ],
     // where to search for files/tests
     roots: srcRoots.map(toRelRootDir),
     testEnvironment: 'node',


### PR DESCRIPTION
Added jest-watch-typeahead to for better development experience and ease of use.

<img width="536" alt="Screenshot 2022-04-28 at 10 59 10" src="https://user-images.githubusercontent.com/59263605/165707118-c01b907e-38fb-472f-8efd-731b286321d6.png">

Closes #5
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/scripts@1.12.0-canary.56.2237961680.0
  # or 
  yarn add @tablecheck/scripts@1.12.0-canary.56.2237961680.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
