### PR TITLE
fix(scripts): fix compatibilty issues with latest storybook

### DIFF
--- a/packages/scripts/config/storybook.main.js
+++ b/packages/scripts/config/storybook.main.js
@@ -8,6 +8,11 @@ module.exports = {
   // our babel-plugin doesn't play nice with storybook, the only extra thing we need though is this plugin
   babel: (options) => ({
     ...options,
+    presets: options.presets.map((arg) =>
+      Array.isArray(arg) && /\/@babel\/preset-react\//gi.test(arg[0])
+        ? [arg[0], { runtime: 'automatic', importSource: '@emotion/react' }]
+        : arg
+    ),
     plugins: [...options.plugins, '@emotion/babel-plugin']
   }),
   webpackFinal: async (config) => {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -37,7 +37,8 @@
     "razzle": "^4.2.16",
     "razzle-dev-utils": "^4.2.16",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "storybook": "^6.4.0"
   },
   "dependencies": {
     "@babel/core": "^7.17.8",

--- a/packages/scripts/templates/.storybook/main.js
+++ b/packages/scripts/templates/.storybook/main.js
@@ -1,1 +1,9 @@
-module.exports = require('@tablecheck/scripts/config/storybook.main');
+const mainConfig = require('@tablecheck/scripts/config/storybook.main');
+
+module.exports = {
+  ...mainConfig,
+  features: {
+    babelModeV7: true
+  },
+  addons: [...mainConfig.addons]
+};


### PR DESCRIPTION
Fixing babel issues with latest storybook, if there you had a `.storybook/.babelrc` file to fix babel issues it can be deleted as it should no longer be necessary.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/scripts@1.12.1-canary.59.2306364484.0
  # or 
  yarn add @tablecheck/scripts@1.12.1-canary.59.2306364484.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
