### PR TITLE
fix(eslint-config): override max lines for certain files

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -75,7 +75,8 @@ const config = {
     require('./overrides/typescriptDefinitions'),
     require('./overrides/typescriptDocumentation'),
     require('./overrides/scripts'),
-    require('./overrides/documentation')
+    require('./overrides/documentation'),
+    require('./overrides/maxLines')
   ],
 
   rules: {

--- a/packages/eslint-config/overrides/maxLines.js
+++ b/packages/eslint-config/overrides/maxLines.js
@@ -1,0 +1,11 @@
+module.exports = {
+  files: [
+    '**/types.ts',
+    '**/*.types.ts',
+    '**/machine.{ts,tsx,js,jsx,mjs,cjs}',
+    '**/*.machine.{ts,tsx,js,jsx,mjs,cjs}'
+  ],
+  rules: {
+    'max-lines': 'off'
+  }
+};


### PR DESCRIPTION
fixes #58
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/eslint-config@1.7.2-canary.60.2317081826.0
  npm install @tablecheck/scripts@1.12.2-canary.60.2317081826.0
  # or 
  yarn add @tablecheck/eslint-config@1.7.2-canary.60.2317081826.0
  yarn add @tablecheck/scripts@1.12.2-canary.60.2317081826.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
