### PR TITLE
fix: typo in “include”

### DIFF
--- a/packages/scripts/scripts/utils/configureTypescript.js
+++ b/packages/scripts/scripts/utils/configureTypescript.js
@@ -239,7 +239,7 @@ module.exports = {
         include: eslintRoots,
         compilerOptions: {
           noEmit: true,
-          types: eslintRoots.include('cypress')
+          types: eslintRoots.includes('cypress')
             ? ['cypress', 'node']
             : undefined
         }


### PR DESCRIPTION
This was a really dumb typo...
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/scripts@1.12.3-canary.61.2349661341.0
  # or 
  yarn add @tablecheck/scripts@1.12.3-canary.61.2349661341.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
