### PR TITLE
fix(scripts): switch sspa library output to window

### DIFF
--- a/packages/scripts/razzle/sspa.js
+++ b/packages/scripts/razzle/sspa.js
@@ -25,7 +25,7 @@ module.exports = baseConfig.extend({
       webpackConfigDraft.output = webpackConfigDraft.output || {};
       if (!argv.standalone) {
         webpackConfigDraft.output.library = appPackage.name;
-        webpackConfigDraft.output.libraryTarget = 'amd';
+        webpackConfigDraft.output.libraryTarget = 'window';
       }
       webpackConfigDraft.plugins.push(
         new WebpackManifestPlugin({


### PR DESCRIPTION
Changing our SSPA lib output from amd define to window var. This prevent us from clashing with define implementations of other libraries as ours was incomplete. This is simpler and less prone to breaking than the incomplete define plugin. Related to RFC-19
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/scripts@2.0.0-canary.63.2369157285.0
  # or 
  yarn add @tablecheck/scripts@2.0.0-canary.63.2369157285.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
