### PR TITLE
feat(scripts): add carbon icon types generation

### DIFF
--- a/auditjs.json
+++ b/auditjs.json
@@ -650,6 +650,37 @@
           "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2021-0749?component-type=npm&component-name=request&utm_source=auditjs&utm_medium=integration&utm_content=4.0.37"
         }
       ]
+    },
+    {
+      "coordinates": "pkg:npm/nwsapi@2.2.0",
+      "description": "Fast CSS Selectors API Engine",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/nwsapi@2.2.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.36",
+      "vulnerabilities": [
+        {
+          "id": "sonatype-2022-3565",
+          "title": "[sonatype-2022-3565] CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')",
+          "description": "nwsapi - Denial of Service (DoS)\n\nThe software does not properly restrict the size or amount of resources that are requested or influenced by an actor, which can be used to consume more resources than intended.",
+          "cvssScore": 6.2,
+          "cvssVector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2022-3565?component-type=npm&component-name=nwsapi&utm_source=auditjs&utm_medium=integration&utm_content=4.0.36"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/got@9.6.0",
+      "description": "Human-friendly and powerful HTTP request library for Node.js",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/got@9.6.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.36",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-33987",
+          "title": "[CVE-2022-33987] CWE-601: URL Redirection to Untrusted Site ('Open Redirect')",
+          "description": "The got package before 12.1.0 for Node.js allows a redirect to a UNIX socket.",
+          "cvssScore": 6.1,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+          "cve": "CVE-2022-33987",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-33987?component-type=npm&component-name=got&utm_source=auditjs&utm_medium=integration&utm_content=4.0.36"
+        }
+      ]
     }
   ],
   "ignore": [
@@ -778,6 +809,12 @@
     },
     {
       "id": "sonatype-2021-0749"
+    },
+    {
+      "id": "sonatype-2022-3565"
+    },
+    {
+      "id": "CVE-2022-33987"
     }
   ]
 }

--- a/packages/scripts/scripts/utils/configureTypescript.js
+++ b/packages/scripts/scripts/utils/configureTypescript.js
@@ -14,6 +14,10 @@ const {
   writeConfigDefinition,
   systemDefinitionFilePath
 } = require('./writeConfigDefinition');
+const {
+  writeCarbonIconTypes,
+  carbonIconTypesFilePath
+} = require('./writeCarbonIconTypes');
 
 const excludeWithTests = [
   'node_modules',
@@ -31,7 +35,8 @@ function writeTsConfig(filePath, configArg, forceConfig = false) {
   let sourceFiles = [];
   const config = {
     ...configArg,
-    include: configArg.include ? [...configArg.include] : undefined
+    include: configArg.include ? [...configArg.include] : undefined,
+    files: configArg.files.filter((filepath) => fs.existsSync(filepath))
   };
   if (config.include) {
     if (argv.verbose) {
@@ -114,6 +119,7 @@ module.exports = {
   ) => {
     const packageFilter = shouldIgnorePackageArg ? '*' : argv.package;
     writeConfigDefinition();
+    writeCarbonIconTypes();
     // this is gonna seem pretty weird, but here we are going to MODIFY the json tsconfig files
 
     // first we see if we are in a lerna repo
@@ -122,7 +128,7 @@ module.exports = {
     // https://github.com/microsoft/TypeScript/issues/27098
     const runnerConfigPath = path.join(paths.cwd, 'tsconfig.json');
     // this needs to be in every package or the CONFIG var isn't resolved
-    const files = [systemDefinitionFilePath];
+    const files = [systemDefinitionFilePath, carbonIconTypesFilePath];
     const packageConfig = {
       extends: '@tablecheck/scripts/tsconfig/lib.json',
       exclude: isBuild ? excludeWithTests : ['node_modules'],
@@ -254,6 +260,7 @@ module.exports = {
   },
   configureAppTypescript: (isBuild) => {
     writeConfigDefinition();
+    writeCarbonIconTypes();
 
     const include = ['src'];
     if (fs.existsSync(paths.storybook)) {
@@ -263,7 +270,7 @@ module.exports = {
     const config = {
       extends: '@tablecheck/scripts/tsconfig/base.json',
       exclude: isBuild ? excludeWithTests : ['node_modules'],
-      files: [systemDefinitionFilePath],
+      files: [systemDefinitionFilePath, carbonIconTypesFilePath],
       include,
       compilerOptions: {
         lib: ['dom', 'dom.iterable', 'esnext'],

--- a/packages/scripts/scripts/utils/writeCarbonIconTypes.js
+++ b/packages/scripts/scripts/utils/writeCarbonIconTypes.js
@@ -1,0 +1,113 @@
+const path = require('path');
+
+const chalk = require('chalk');
+const fs = require('fs-extra');
+const minimist = require('minimist');
+const prettier = require('prettier');
+const semver = require('semver');
+
+const paths = require('../../config/paths');
+
+const { logTaskEnd, logTaskStart } = require('./taskLogFormatter');
+
+const argv = minimist(process.argv.slice(2), {
+  boolean: ['verbose'],
+  default: {
+    verbose: false
+  }
+});
+
+const systemCacheFolderName = '.@tablecheck';
+const systemCacheFolderPath = path.join(paths.cwd, systemCacheFolderName);
+
+const carbonIconTypesFilePath = path.join(
+  systemCacheFolderPath,
+  'carbonIcons.d.ts'
+);
+
+const carbonPackageName = '@carbon/icons-react';
+
+function writeCarbonIconTypes() {
+  const carbonPackageJsonPath = path.join(
+    paths.cwd,
+    'node_modules',
+    carbonPackageName,
+    'package.json'
+  );
+  if (!fs.existsSync(carbonPackageJsonPath)) {
+    if (argv.verbose) {
+      console.log(
+        chalk.gray(`Carbon Icons not detected at '${carbonPackageJsonPath}'`)
+      );
+    }
+    return;
+  }
+  const carbonPackageJson = fs.readJSONSync(carbonPackageJsonPath);
+  if (
+    !carbonPackageJson.version ||
+    !semver.satisfies(carbonPackageJson.version, '^11')
+  ) {
+    if (argv.verbose) {
+      console.log(
+        chalk.gray(
+          `Carbon Icons is not version 11, actual version '${carbonPackageJson.version}'`
+        )
+      );
+    }
+    return;
+  }
+  if (argv.verbose) {
+    console.log(
+      chalk.gray(
+        `Carbon Icons at version '${carbonPackageJson.version}' detected, will generate types.`
+      )
+    );
+  }
+  logTaskStart('Generating types for @carbon/icons-react@11');
+  if (
+    fs.existsSync(
+      path.join(
+        paths.cwd,
+        'node_modules/@types/carbon__icons-react/package.json'
+      )
+    )
+  ) {
+    console.log(
+      chalk.yellow(
+        'Please uninstall `@types/carbon__icons-react` to use the generated types.'
+      )
+    );
+  }
+  const carbonIcons = require(carbonPackageName);
+  const fileContent = `${Object.keys(carbonIcons).reduce(
+    (result, iconName) =>
+      `${result}  declare export const ${iconName}: CarbonIcon;\n`,
+    `/* this file is generated during configuring typescript */
+      declare module '@carbon/icons-react' {
+        declare export type CarbonIconSize = 16 | 20 | 24 | 32;
+        declare export type CarbonIcon = React.ForwardRefExoticComponent<
+          {
+            size: CarbonIconSize | \`\${CarbonIconSize}\` | (string & {}) | (number & {});
+          } & React.RefAttributes<SVGSVGElement>
+        >;
+    `
+  )}\n}`;
+
+  const prettierOptions = prettier.resolveConfig.sync(paths.cwd);
+  fs.writeFileSync(
+    carbonIconTypesFilePath,
+    prettier.format(fileContent, {
+      ...prettierOptions,
+      filepath: carbonIconTypesFilePath
+    })
+  );
+
+  logTaskEnd(true);
+  if (argv.verbose) {
+    console.log('');
+    console.log(chalk.gray(path.relative(paths.cwd, carbonIconTypesFilePath)));
+    console.log(chalk.gray(fs.readFileSync(carbonIconTypesFilePath, 'utf8')));
+  }
+}
+
+module.exports = { writeCarbonIconTypes, carbonIconTypesFilePath };


### PR DESCRIPTION
If `@carbon/icons-react` at version 11 is installed, we will generate the type definitions automatically and add them to the tsconfig files definition.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/scripts@2.2.0-canary.66.2546496273.0
  # or 
  yarn add @tablecheck/scripts@2.2.0-canary.66.2546496273.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
