### PR TITLE
fix(scripts): change jest-watch-typeahead to be fixed to v1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
 				"jest-enzyme": "^7.1.2",
 				"jest-junit": "^13.0.0",
 				"jest-transform-graphql": "^2.1.0",
-				"jest-watch-typeahead": "^1.1.0",
+				"jest-watch-typeahead": "1.0.0",
 				"jscodeshift": "^0.13.1",
 				"mini-css-extract-plugin": "^2.6.0",
 				"minimatch": "^5.0.1",
@@ -3149,16 +3149,6 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/@jest/schemas": {
-			"version": "28.0.2",
-			"license": "MIT",
-			"dependencies": {
-				"@sinclair/typebox": "^0.23.3"
-			},
-			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
 			}
 		},
 		"node_modules/@jest/source-map": {
@@ -9155,10 +9145,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/@sinclair/typebox": {
-			"version": "0.23.4",
-			"license": "MIT"
 		},
 		"node_modules/@sindresorhus/is": {
 			"version": "0.14.0",
@@ -24586,13 +24572,14 @@
 			}
 		},
 		"node_modules/jest-watch-typeahead": {
-			"version": "1.1.0",
-			"license": "MIT",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/jest-watch-typeahead/-/jest-watch-typeahead-1.0.0.tgz",
+			"integrity": "sha512-jxoszalAb394WElmiJTFBMzie/RDCF+W7Q29n5LzOPtcoQoHWfdUtHFkbhgf5NwWe8uMOxvKb/g7ea7CshfkTw==",
 			"dependencies": {
 				"ansi-escapes": "^4.3.1",
 				"chalk": "^4.0.0",
-				"jest-regex-util": "^28.0.0",
-				"jest-watcher": "^28.0.0",
+				"jest-regex-util": "^27.0.0",
+				"jest-watcher": "^27.0.0",
 				"slash": "^4.0.0",
 				"string-length": "^5.0.1",
 				"strip-ansi": "^7.0.1"
@@ -24601,191 +24588,32 @@
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
 			"peerDependencies": {
-				"jest": "^27.0.0 || ^28.0.0"
+				"jest": "^27.0.0"
 			}
 		},
-		"node_modules/jest-watch-typeahead/node_modules/@jest/console": {
-			"version": "28.0.2",
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^28.0.2",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"jest-message-util": "^28.0.2",
-				"jest-util": "^28.0.2",
-				"slash": "^3.0.0"
-			},
-			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-			}
-		},
-		"node_modules/jest-watch-typeahead/node_modules/@jest/console/node_modules/slash": {
-			"version": "3.0.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/jest-watch-typeahead/node_modules/@jest/test-result": {
-			"version": "28.0.2",
-			"license": "MIT",
-			"dependencies": {
-				"@jest/console": "^28.0.2",
-				"@jest/types": "^28.0.2",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"collect-v8-coverage": "^1.0.0"
-			},
-			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-			}
-		},
-		"node_modules/jest-watch-typeahead/node_modules/@jest/types": {
-			"version": "28.0.2",
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^28.0.2",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
-				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
-			},
-			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-			}
-		},
-		"node_modules/jest-watch-typeahead/node_modules/@types/yargs": {
-			"version": "17.0.10",
-			"license": "MIT",
-			"dependencies": {
-				"@types/yargs-parser": "*"
-			}
-		},
-		"node_modules/jest-watch-typeahead/node_modules/ansi-styles": {
-			"version": "5.2.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/jest-watch-typeahead/node_modules/emittery": {
-			"version": "0.10.2",
-			"license": "MIT",
+		"node_modules/jest-watch-typeahead/node_modules/ansi-regex": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
 			"engines": {
 				"node": ">=12"
 			},
 			"funding": {
-				"url": "https://github.com/sindresorhus/emittery?sponsor=1"
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
 			}
 		},
-		"node_modules/jest-watch-typeahead/node_modules/jest-message-util": {
-			"version": "28.0.2",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.12.13",
-				"@jest/types": "^28.0.2",
-				"@types/stack-utils": "^2.0.0",
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
-				"micromatch": "^4.0.4",
-				"pretty-format": "^28.0.2",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.3"
-			},
+		"node_modules/jest-watch-typeahead/node_modules/char-regex": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-2.0.1.tgz",
+			"integrity": "sha512-oSvEeo6ZUD7NepqAat3RqoucZ5SeqLJgOvVIwkafu6IP3V0pO38s/ypdVUmDDK6qIIHNlYHJAKX9E7R7HoKElw==",
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+				"node": ">=12.20"
 			}
-		},
-		"node_modules/jest-watch-typeahead/node_modules/jest-message-util/node_modules/slash": {
-			"version": "3.0.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/jest-watch-typeahead/node_modules/jest-regex-util": {
-			"version": "28.0.2",
-			"license": "MIT",
-			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-			}
-		},
-		"node_modules/jest-watch-typeahead/node_modules/jest-util": {
-			"version": "28.0.2",
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^28.0.2",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
-			},
-			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-			}
-		},
-		"node_modules/jest-watch-typeahead/node_modules/jest-watcher": {
-			"version": "28.0.2",
-			"license": "MIT",
-			"dependencies": {
-				"@jest/test-result": "^28.0.2",
-				"@jest/types": "^28.0.2",
-				"@types/node": "*",
-				"ansi-escapes": "^4.2.1",
-				"chalk": "^4.0.0",
-				"emittery": "^0.10.2",
-				"jest-util": "^28.0.2",
-				"string-length": "^4.0.1"
-			},
-			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-			}
-		},
-		"node_modules/jest-watch-typeahead/node_modules/jest-watcher/node_modules/string-length": {
-			"version": "4.0.2",
-			"license": "MIT",
-			"dependencies": {
-				"char-regex": "^1.0.2",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/jest-watch-typeahead/node_modules/jest-watcher/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/jest-watch-typeahead/node_modules/pretty-format": {
-			"version": "28.0.2",
-			"license": "MIT",
-			"dependencies": {
-				"@jest/schemas": "^28.0.2",
-				"ansi-regex": "^5.0.1",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^18.0.0"
-			},
-			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-			}
-		},
-		"node_modules/jest-watch-typeahead/node_modules/react-is": {
-			"version": "18.1.0",
-			"license": "MIT"
 		},
 		"node_modules/jest-watch-typeahead/node_modules/slash": {
 			"version": "4.0.0",
-			"license": "MIT",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+			"integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
 			"engines": {
 				"node": ">=12"
 			},
@@ -24795,7 +24623,8 @@
 		},
 		"node_modules/jest-watch-typeahead/node_modules/string-length": {
 			"version": "5.0.1",
-			"license": "MIT",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-5.0.1.tgz",
+			"integrity": "sha512-9Ep08KAMUn0OadnVaBuRdE2l615CQ508kr0XMadjClfYpdCyvrbFp6Taebo8yyxokQ4viUd/xPPUA4FGgUa0ow==",
 			"dependencies": {
 				"char-regex": "^2.0.0",
 				"strip-ansi": "^7.0.1"
@@ -24807,16 +24636,10 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/jest-watch-typeahead/node_modules/string-length/node_modules/char-regex": {
-			"version": "2.0.1",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.20"
-			}
-		},
 		"node_modules/jest-watch-typeahead/node_modules/strip-ansi": {
 			"version": "7.0.1",
-			"license": "MIT",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+			"integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
 			"dependencies": {
 				"ansi-regex": "^6.0.1"
 			},
@@ -24825,16 +24648,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
-			}
-		},
-		"node_modules/jest-watch-typeahead/node_modules/strip-ansi/node_modules/ansi-regex": {
-			"version": "6.0.1",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
 			}
 		},
 		"node_modules/jest-watcher": {
@@ -26718,9 +26531,9 @@
 			}
 		},
 		"node_modules/mini-css-extract-plugin": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.6.0.tgz",
-			"integrity": "sha512-ndG8nxCEnAemsg4FSgS+yNyHKgkTB4nPKqCOgh65j3/30qqC5RaSQQXMm++Y6sb6E1zRSxPkztj9fqxhS1Eo6w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.6.1.tgz",
+			"integrity": "sha512-wd+SD57/K6DiV7jIR34P+s3uckTRuQvx0tKPcvjFlrEylk6P4mQ2KSWk1hblj1Kxaqok7LogKOieygXqBczNlg==",
 			"dependencies": {
 				"schema-utils": "^4.0.0"
 			},
@@ -40216,7 +40029,7 @@
 		},
 		"packages/scripts": {
 			"name": "@tablecheck/scripts",
-			"version": "2.0.0",
+			"version": "2.2.0",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -40266,7 +40079,7 @@
 				"jest-enzyme": "^7.1.2",
 				"jest-junit": "^13.0.0",
 				"jest-transform-graphql": "^2.1.0",
-				"jest-watch-typeahead": "^1.1.0",
+				"jest-watch-typeahead": "1.0.0",
 				"jscodeshift": "^0.13.1",
 				"lint-staged": "^11.2.6",
 				"lodash": "^4.17.21",
@@ -54348,12 +54161,6 @@
 				}
 			}
 		},
-		"@jest/schemas": {
-			"version": "28.0.2",
-			"requires": {
-				"@sinclair/typebox": "^0.23.3"
-			}
-		},
 		"@jest/source-map": {
 			"version": "27.5.1",
 			"requires": {
@@ -58966,9 +58773,6 @@
 				}
 			}
 		},
-		"@sinclair/typebox": {
-			"version": "0.23.4"
-		},
 		"@sindresorhus/is": {
 			"version": "0.14.0",
 			"dev": true
@@ -60659,7 +60463,7 @@
 				"jest-enzyme": "^7.1.2",
 				"jest-junit": "^13.0.0",
 				"jest-transform-graphql": "^2.1.0",
-				"jest-watch-typeahead": "^1.1.0",
+				"jest-watch-typeahead": "1.0.0",
 				"jscodeshift": "^0.13.1",
 				"lint-staged": "^11.2.6",
 				"lodash": "^4.17.21",
@@ -77683,162 +77487,49 @@
 			}
 		},
 		"jest-watch-typeahead": {
-			"version": "1.1.0",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/jest-watch-typeahead/-/jest-watch-typeahead-1.0.0.tgz",
+			"integrity": "sha512-jxoszalAb394WElmiJTFBMzie/RDCF+W7Q29n5LzOPtcoQoHWfdUtHFkbhgf5NwWe8uMOxvKb/g7ea7CshfkTw==",
 			"requires": {
 				"ansi-escapes": "^4.3.1",
 				"chalk": "^4.0.0",
-				"jest-regex-util": "^28.0.0",
-				"jest-watcher": "^28.0.0",
+				"jest-regex-util": "^27.0.0",
+				"jest-watcher": "^27.0.0",
 				"slash": "^4.0.0",
 				"string-length": "^5.0.1",
 				"strip-ansi": "^7.0.1"
 			},
 			"dependencies": {
-				"@jest/console": {
-					"version": "28.0.2",
-					"requires": {
-						"@jest/types": "^28.0.2",
-						"@types/node": "*",
-						"chalk": "^4.0.0",
-						"jest-message-util": "^28.0.2",
-						"jest-util": "^28.0.2",
-						"slash": "^3.0.0"
-					},
-					"dependencies": {
-						"slash": {
-							"version": "3.0.0"
-						}
-					}
+				"ansi-regex": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+					"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
 				},
-				"@jest/test-result": {
-					"version": "28.0.2",
-					"requires": {
-						"@jest/console": "^28.0.2",
-						"@jest/types": "^28.0.2",
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"collect-v8-coverage": "^1.0.0"
-					}
-				},
-				"@jest/types": {
-					"version": "28.0.2",
-					"requires": {
-						"@jest/schemas": "^28.0.2",
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/istanbul-reports": "^3.0.0",
-						"@types/node": "*",
-						"@types/yargs": "^17.0.8",
-						"chalk": "^4.0.0"
-					}
-				},
-				"@types/yargs": {
-					"version": "17.0.10",
-					"requires": {
-						"@types/yargs-parser": "*"
-					}
-				},
-				"ansi-styles": {
-					"version": "5.2.0"
-				},
-				"emittery": {
-					"version": "0.10.2"
-				},
-				"jest-message-util": {
-					"version": "28.0.2",
-					"requires": {
-						"@babel/code-frame": "^7.12.13",
-						"@jest/types": "^28.0.2",
-						"@types/stack-utils": "^2.0.0",
-						"chalk": "^4.0.0",
-						"graceful-fs": "^4.2.9",
-						"micromatch": "^4.0.4",
-						"pretty-format": "^28.0.2",
-						"slash": "^3.0.0",
-						"stack-utils": "^2.0.3"
-					},
-					"dependencies": {
-						"slash": {
-							"version": "3.0.0"
-						}
-					}
-				},
-				"jest-regex-util": {
-					"version": "28.0.2"
-				},
-				"jest-util": {
-					"version": "28.0.2",
-					"requires": {
-						"@jest/types": "^28.0.2",
-						"@types/node": "*",
-						"chalk": "^4.0.0",
-						"ci-info": "^3.2.0",
-						"graceful-fs": "^4.2.9",
-						"picomatch": "^2.2.3"
-					}
-				},
-				"jest-watcher": {
-					"version": "28.0.2",
-					"requires": {
-						"@jest/test-result": "^28.0.2",
-						"@jest/types": "^28.0.2",
-						"@types/node": "*",
-						"ansi-escapes": "^4.2.1",
-						"chalk": "^4.0.0",
-						"emittery": "^0.10.2",
-						"jest-util": "^28.0.2",
-						"string-length": "^4.0.1"
-					},
-					"dependencies": {
-						"string-length": {
-							"version": "4.0.2",
-							"requires": {
-								"char-regex": "^1.0.2",
-								"strip-ansi": "^6.0.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "6.0.1",
-							"requires": {
-								"ansi-regex": "^5.0.1"
-							}
-						}
-					}
-				},
-				"pretty-format": {
-					"version": "28.0.2",
-					"requires": {
-						"@jest/schemas": "^28.0.2",
-						"ansi-regex": "^5.0.1",
-						"ansi-styles": "^5.0.0",
-						"react-is": "^18.0.0"
-					}
-				},
-				"react-is": {
-					"version": "18.1.0"
+				"char-regex": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-2.0.1.tgz",
+					"integrity": "sha512-oSvEeo6ZUD7NepqAat3RqoucZ5SeqLJgOvVIwkafu6IP3V0pO38s/ypdVUmDDK6qIIHNlYHJAKX9E7R7HoKElw=="
 				},
 				"slash": {
-					"version": "4.0.0"
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+					"integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew=="
 				},
 				"string-length": {
 					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/string-length/-/string-length-5.0.1.tgz",
+					"integrity": "sha512-9Ep08KAMUn0OadnVaBuRdE2l615CQ508kr0XMadjClfYpdCyvrbFp6Taebo8yyxokQ4viUd/xPPUA4FGgUa0ow==",
 					"requires": {
 						"char-regex": "^2.0.0",
 						"strip-ansi": "^7.0.1"
-					},
-					"dependencies": {
-						"char-regex": {
-							"version": "2.0.1"
-						}
 					}
 				},
 				"strip-ansi": {
 					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+					"integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
 					"requires": {
 						"ansi-regex": "^6.0.1"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "6.0.1"
-						}
 					}
 				}
 			}
@@ -79106,9 +78797,9 @@
 			"version": "1.0.1"
 		},
 		"mini-css-extract-plugin": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.6.0.tgz",
-			"integrity": "sha512-ndG8nxCEnAemsg4FSgS+yNyHKgkTB4nPKqCOgh65j3/30qqC5RaSQQXMm++Y6sb6E1zRSxPkztj9fqxhS1Eo6w==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.6.1.tgz",
+			"integrity": "sha512-wd+SD57/K6DiV7jIR34P+s3uckTRuQvx0tKPcvjFlrEylk6P4mQ2KSWk1hblj1Kxaqok7LogKOieygXqBczNlg==",
 			"requires": {
 				"schema-utils": "^4.0.0"
 			},

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -87,7 +87,7 @@
     "jest-enzyme": "^7.1.2",
     "jest-junit": "^13.0.0",
     "jest-transform-graphql": "^2.1.0",
-    "jest-watch-typeahead": "^1.1.0",
+    "jest-watch-typeahead": "1.0.0",
     "jscodeshift": "^0.13.1",
     "lint-staged": "^11.2.6",
     "lodash": "^4.17.21",


### PR DESCRIPTION
v1.1.0 uses jest@28 and we haven't upgraded to that yet. See https://github.com/jest-community/jest-watch-typeahead/blob/main/CHANGELOG.md
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/scripts@2.2.1-canary.67.2553811532.0
  # or 
  yarn add @tablecheck/scripts@2.2.1-canary.67.2553811532.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
