### PR TITLE
fix(scripts): non build tsc would fail if there is only one project

### DIFF
--- a/auditjs.json
+++ b/auditjs.json
@@ -768,6 +768,54 @@
           "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2022-3677?component-type=npm&component-name=node-fetch&utm_source=auditjs&utm_medium=integration&utm_content=4.0.37"
         }
       ]
+    },
+    {
+      "coordinates": "pkg:npm/terser@4.8.0",
+      "description": "JavaScript parser, mangler/compressor and beautifier toolkit for ES6+",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/terser@4.8.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.37",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-25858",
+          "title": "[CVE-2022-25858] The package terser before 4.8.1, from 5.0.0 and before 5.14.2 are vulnerable to Regular Expression Denial of Service (ReDoS) due to insecure usage of regular expressions.",
+          "description": "The package terser before 4.8.1, from 5.0.0 and before 5.14.2 are vulnerable to Regular Expression Denial of Service (ReDoS) due to insecure usage of regular expressions.",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2022-25858",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-25858?component-type=npm&component-name=terser&utm_source=auditjs&utm_medium=integration&utm_content=4.0.37"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/terser@5.14.1",
+      "description": "JavaScript parser, mangler/compressor and beautifier toolkit for ES6+",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/terser@5.14.1?utm_source=auditjs&utm_medium=integration&utm_content=4.0.37",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-25858",
+          "title": "[CVE-2022-25858] The package terser before 4.8.1, from 5.0.0 and before 5.14.2 are vulnerable to Regular Expression Denial of Service (ReDoS) due to insecure usage of regular expressions.",
+          "description": "The package terser before 4.8.1, from 5.0.0 and before 5.14.2 are vulnerable to Regular Expression Denial of Service (ReDoS) due to insecure usage of regular expressions.",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2022-25858",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-25858?component-type=npm&component-name=terser&utm_source=auditjs&utm_medium=integration&utm_content=4.0.37"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/parse-path@4.0.4",
+      "description": "Parse paths (local paths, urls: ssh/git/etc)",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/parse-path@4.0.4?utm_source=auditjs&utm_medium=integration&utm_content=4.0.37",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-2216",
+          "title": "[CVE-2022-2216] CWE-918: Server-Side Request Forgery (SSRF)",
+          "description": "Server-Side Request Forgery (SSRF) in GitHub repository ionicabizau/parse-url prior to 7.0.0.",
+          "cvssScore": 9.8,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "cve": "CVE-2022-2216",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-2216?component-type=npm&component-name=parse-path&utm_source=auditjs&utm_medium=integration&utm_content=4.0.37"
+        }
+      ]
     }
   ],
   "ignore": [
@@ -920,6 +968,12 @@
     },
     {
       "id": "sonatype-2022-3677"
+    },
+    {
+      "id": "CVE-2022-25858"
+    },
+    {
+      "id": "CVE-2022-2216"
     }
   ]
 }

--- a/packages/scripts/scripts/utils/configureTypescript.js
+++ b/packages/scripts/scripts/utils/configureTypescript.js
@@ -202,6 +202,9 @@ module.exports = {
           path: esmConfigPath
         });
       });
+      if (!isBuild && libConfig.references.length === 1) {
+        libConfig = fs.readJSONSync(libConfig.references[0].path);
+      }
       if (shouldCleanLibs) {
         if (argv.verbose) {
           console.log(chalk.gray('\nCleaning `lib` folders:'));


### PR DESCRIPTION
An issue occured in tablekit-next where if there was only one typescript package the project build would fail with `Debug Failure. project /…/tablekit-next/tsconfig.json expected to have at least one output`

This PR fixes that issue by detecting if we are doing a "type check" (ie non-build) and if there is only one TS project in the lerna repo then we replace the top level config with a copy of the tsconfig in the child project so we then run a "single" run not a projects/workspace run (all paths are absolute so this has no issues).
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/scripts@2.3.1-canary.69.2751406635.0
  # or 
  yarn add @tablecheck/scripts@2.3.1-canary.69.2751406635.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
