### PR TITLE
fix(scripts): precommit should use same configs as lint

### DIFF
--- a/auditjs.json
+++ b/auditjs.json
@@ -816,6 +816,22 @@
           "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-2216?component-type=npm&component-name=parse-path&utm_source=auditjs&utm_medium=integration&utm_content=4.0.37"
         }
       ]
+    },
+    {
+      "coordinates": "pkg:npm/node-fetch@2.6.7",
+      "description": "A light-weight module that brings window.fetch to node.js",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/node-fetch@2.6.7?utm_source=auditjs&utm_medium=integration&utm_content=4.0.37",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-2596",
+          "title": "[CVE-2022-2596] CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')",
+          "description": "Denial of Service in GitHub repository node-fetch/node-fetch prior to 3.2.10.",
+          "cvssScore": 5.9,
+          "cvssVector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2022-2596",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-2596?component-type=npm&component-name=node-fetch&utm_source=auditjs&utm_medium=integration&utm_content=4.0.37"
+        }
+      ]
     }
   ],
   "ignore": [
@@ -974,6 +990,9 @@
     },
     {
       "id": "CVE-2022-2216"
+    },
+    {
+      "id": "CVE-2022-2596"
     }
   ]
 }

--- a/packages/scripts/scripts/precommit.js
+++ b/packages/scripts/scripts/precommit.js
@@ -32,7 +32,7 @@ async function runPrecommit() {
     '**/*.{ts,tsx,js,jsx}': [
       // eslint fix first, otherwise eslint fix may unprettify files
       // also inherently checks typescript
-      'eslint --fix --config ./.eslintrc.js',
+      'eslint --fix',
       'prettier --write'
     ],
     '**/!(*.ts|*.tsx|*.js|*.jsx|package-json.json)': 'prettier --write -u',

--- a/packages/scripts/scripts/utils/package.js
+++ b/packages/scripts/scripts/utils/package.js
@@ -1,5 +1,6 @@
 const path = require('path');
 
+const systemSettings = require('@tablecheck/scripts-utils/userConfig');
 const chalk = require('chalk');
 const fs = require('fs-extra');
 const { uniqBy } = require('lodash');
@@ -235,10 +236,15 @@ async function validateLernaDeps() {
   const lernaPaths = await getLernaPaths();
   const rootPackage = fs.readJSONSync(path.join(process.cwd(), 'package.json'));
   const childPackages = await Promise.all(
-    lernaPaths.map(async (p) => [
-      p,
-      await fs.readJSON(path.join(p, 'package.json'))
-    ])
+    lernaPaths
+      .filter(
+        (name) =>
+          !systemSettings.independentLernaPackages ||
+          !systemSettings.independentLernaPackages.includes(
+            path.relative(process.cwd(), name)
+          )
+      )
+      .map(async (p) => [p, await fs.readJSON(path.join(p, 'package.json'))])
   );
   const rootDependencies = {
     ...(rootPackage.dependencies || {}),


### PR DESCRIPTION
Omiting the config param will correctly resolve to the same config as the normal lint. With the config param it’s resolving somewhere unknown.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/scripts@2.3.3-canary.71.2787011566.0
  # or 
  yarn add @tablecheck/scripts@2.3.3-canary.71.2787011566.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
