### PR TITLE
fix(scripts): typescript for cypress in libraries

### DIFF
--- a/packages/scripts/scripts/utils/configureTypescript.js
+++ b/packages/scripts/scripts/utils/configureTypescript.js
@@ -176,7 +176,8 @@ module.exports = {
             target: 'es5',
             noEmit: true,
             isolatedModules: false,
-            paths: compilerPaths
+            paths: compilerPaths,
+            types: ['cypress', 'node']
           }
         },
         true


### PR DESCRIPTION
Cypress tsconfig.json in Lib setup was missing the types that were in app and eslint setups
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/scripts@2.3.5-canary.73.2910736695.0
  # or 
  yarn add @tablecheck/scripts@2.3.5-canary.73.2910736695.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
