### PR TITLE
fix(scripts): use correct Babel "preset-react" plugin options

### DIFF
--- a/packages/scripts/scripts/rollup/__snapshots__/jsxPlugin.spec.js.snap
+++ b/packages/scripts/scripts/rollup/__snapshots__/jsxPlugin.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`scripts/jsxPlugin should handle basic JSX elements 1`] = `
+exports[`scripts/jsxPlugin with "@emotion/react" should handle basic JSX elements 1`] = `
 "import { jsxs, jsx } from '@emotion/react/jsx-runtime';
 
 function Component() {
@@ -20,7 +20,7 @@ export { Component };
 "
 `;
 
-exports[`scripts/jsxPlugin should handle emotion css 1`] = `
+exports[`scripts/jsxPlugin with "@emotion/react" should handle emotion css 1`] = `
 "import { css } from '@emotion/react';
 import { getThemeValue } from '@tablekit/utils';
 import { tooltipThemeNamespace, tooltipClassicTheme } from './themes';
@@ -53,7 +53,7 @@ export { Tooltip, TooltipPrimitive };
 "
 `;
 
-exports[`scripts/jsxPlugin should handle import alias spread 1`] = `
+exports[`scripts/jsxPlugin with "@emotion/react" should handle import alias spread 1`] = `
 "import { components } from 'my-select';
 import { components as components$1 } from 'react-select';
 import { jsx } from '@emotion/react/jsx-runtime';
@@ -78,7 +78,7 @@ export { createSelect };
 "
 `;
 
-exports[`scripts/jsxPlugin should handle name clashes 1`] = `
+exports[`scripts/jsxPlugin with "@emotion/react" should handle name clashes 1`] = `
 "import { InputLabelWrapper } from './styled/label';
 
 const Label = ({
@@ -89,7 +89,7 @@ export { Label };
 "
 `;
 
-exports[`scripts/jsxPlugin should handle varying import patterns 1`] = `
+exports[`scripts/jsxPlugin with "@emotion/react" should handle varying import patterns 1`] = `
 "import { Component } from './component';
 import { components } from './components';
 import DefaultComponent from './defaults';
@@ -103,6 +103,119 @@ function TestComponent() {
       children: \\"Children\\"
     }), jsx(DefaultComponent, {
       children: jsx(\\"div\\", {
+        children: \\"Excess\\"
+      })
+    })]
+  });
+}
+
+export { TestComponent as default };
+"
+`;
+
+exports[`scripts/jsxPlugin with "react" should handle basic JSX elements 1`] = `
+"import { jsxs, jsx } from 'react/jsx-runtime';
+
+function Component() {
+  return /*#__PURE__*/jsxs(\\"div\\", {
+    children: [/*#__PURE__*/jsx(\\"link\\", {
+      type: \\"self closing\\"
+    }), /*#__PURE__*/jsx(\\"p\\", {
+      children: /*#__PURE__*/jsx(\\"a\\", {
+        href: \\"123\\",
+        children: \\"Link Content\\"
+      })
+    })]
+  });
+}
+
+export { Component };
+"
+`;
+
+exports[`scripts/jsxPlugin with "react" should handle emotion css 1`] = `
+"import { css } from '@emotion/react';
+import { getThemeValue } from '@tablekit/utils';
+import { tooltipThemeNamespace, tooltipClassicTheme } from './themes';
+
+const TooltipPrimitive = styled.div\`
+  pointer-events: none;
+  position: fixed;
+\`;
+const Tooltip = styled(TooltipPrimitive)\`
+  background-color: \${getThemeValue(\`\${tooltipThemeNamespace}.backgroundColor\`, tooltipClassicTheme.backgroundColor)};
+  color: \${getThemeValue(\`\${tooltipThemeNamespace}.textColor\`, tooltipClassicTheme.textColor)};
+  top: 0;
+  left: 0;
+  line-height: 16px;
+  max-width: 240px;
+
+  \${({
+  isSelected,
+  theme
+}) => {
+  if (isSelected) {
+    return css(\\"color:white;background-color:\\", theme.colors.primary, \\";&:hover{background-color:\\", theme.colors.primary2, \\";}\\" + (process.env.NODE_ENV === \\"production\\" ? \\"\\" : \\";label:Tooltip;\\"));
+  }
+
+  return '';
+}}
+\`;
+
+export { Tooltip, TooltipPrimitive };
+"
+`;
+
+exports[`scripts/jsxPlugin with "react" should handle import alias spread 1`] = `
+"import { components } from 'my-select';
+import { components as components$1 } from 'react-select';
+import { jsx } from 'react/jsx-runtime';
+
+function createSelect(props) {
+  const {
+    MyControl
+  } = components;
+  const {
+    Control
+  } = components$1;
+  return /*#__PURE__*/jsx(Control, { ...props,
+    children: /*#__PURE__*/jsx(MyControl, {
+      children: /*#__PURE__*/jsx(\\"div\\", {
+        children: \\"Test\\"
+      })
+    })
+  });
+}
+
+export { createSelect };
+"
+`;
+
+exports[`scripts/jsxPlugin with "react" should handle name clashes 1`] = `
+"import { InputLabelWrapper } from './styled/label';
+
+const Label = ({
+  label
+}) => InputLabelWrapper(label);
+
+export { Label };
+"
+`;
+
+exports[`scripts/jsxPlugin with "react" should handle varying import patterns 1`] = `
+"import { Component } from './component';
+import { components } from './components';
+import DefaultComponent from './defaults';
+import { jsxs, jsx } from 'react/jsx-runtime';
+
+function TestComponent() {
+  return /*#__PURE__*/jsxs(\\"div\\", {
+    children: [/*#__PURE__*/jsx(Component, {
+      prop1: 12
+    }), /*#__PURE__*/jsx(components.SomeProp, {
+      children: \\"Children\\"
+    }), /*#__PURE__*/jsx(DefaultComponent, {
+      children: /*#__PURE__*/jsx(\\"div\\", {
         children: \\"Excess\\"
       })
     })]

--- a/packages/scripts/scripts/rollup/buildPackage.js
+++ b/packages/scripts/scripts/rollup/buildPackage.js
@@ -149,7 +149,7 @@ function loadRollupConfig(
         requireReturnsDefault: 'namespace'
       }),
       json(),
-      jsxPlugin()
+      jsxPlugin(packagePath)
     ].filter((v) => !!v)
   };
   if (argv.verbose) {

--- a/packages/scripts/scripts/rollup/fixtures/packageWithEmotionReact.json
+++ b/packages/scripts/scripts/rollup/fixtures/packageWithEmotionReact.json
@@ -1,0 +1,9 @@
+{
+  "name": "package with @emotion/react",
+  "dependencies": {},
+  "peerDependencies": {
+    "@emotion/react": ">=11.4 <12",
+    "react": ">=16.8.0 <18",
+    "react-dom": ">=16.2.0 <18"
+  }
+}

--- a/packages/scripts/scripts/rollup/fixtures/packageWithReact.json
+++ b/packages/scripts/scripts/rollup/fixtures/packageWithReact.json
@@ -1,0 +1,8 @@
+{
+  "name": "package with react",
+  "dependencies": {},
+  "peerDependencies": {
+    "react": ">=16.8.0 <18",
+    "react-dom": ">=16.2.0 <18"
+  }
+}

--- a/packages/scripts/scripts/rollup/jsxPlugin.js
+++ b/packages/scripts/scripts/rollup/jsxPlugin.js
@@ -1,8 +1,9 @@
 const jsx = require('acorn-jsx');
 const babel = require('@babel/core');
+const { checkEmotionReactDeps } = require('../utils/package');
 
 module.exports = {
-  jsxPlugin: () => ({
+  jsxPlugin: (packagePath) => ({
     options(inputOptions) {
       const acornPlugins =
         inputOptions.acornInjectPlugins ||
@@ -18,7 +19,9 @@ module.exports = {
             presets: [
               [
                 '@babel/preset-react',
-                { runtime: 'automatic', importSource: '@emotion/react' }
+                checkEmotionReactDeps(packagePath)
+                  ? { runtime: 'automatic', importSource: '@emotion/react' }
+                  : { runtime: 'automatic' }
               ]
             ]
           },

--- a/packages/scripts/scripts/rollup/jsxPlugin.spec.js
+++ b/packages/scripts/scripts/rollup/jsxPlugin.spec.js
@@ -1,10 +1,14 @@
 const rollup = require('rollup');
 const { jsxPlugin } = require('./jsxPlugin');
 
-function testCode(name, filePath) {
+function testCode(name, filePath, usePackageWithEmotionReact = false) {
   // eslint-disable-next-line jest/valid-title
   test(name, async () => {
     const resolvedFilePath = require.resolve(filePath);
+    const packagePath = usePackageWithEmotionReact
+      ? './fixtures/packageWithEmotionReact.json'
+      : './fixtures/packageWithReact.json';
+    const resolvedPackagePath = require.resolve(packagePath);
     const bundle = await rollup.rollup({
       input: resolvedFilePath,
       plugins: [
@@ -16,7 +20,7 @@ function testCode(name, filePath) {
             return { id, external: true };
           }
         },
-        jsxPlugin()
+        jsxPlugin(resolvedPackagePath)
       ]
     });
     const generated = await bundle.generate({ format: 'esm' });
@@ -24,7 +28,7 @@ function testCode(name, filePath) {
   });
 }
 
-describe('scripts/jsxPlugin', () => {
+describe('scripts/jsxPlugin with "react"', () => {
   testCode('should handle basic JSX elements', './fixtures/basic.jsx');
 
   testCode(
@@ -37,4 +41,28 @@ describe('scripts/jsxPlugin', () => {
   testCode('should handle import alias spread', './fixtures/aliasSpread.jsx');
 
   testCode('should handle emotion css', './fixtures/emotionCss.jsx');
+});
+
+describe('scripts/jsxPlugin with "@emotion/react"', () => {
+  testCode('should handle basic JSX elements', './fixtures/basic.jsx', true);
+
+  testCode(
+    'should handle varying import patterns',
+    './fixtures/importedComponents.jsx',
+    true
+  );
+
+  testCode(
+    'should handle name clashes',
+    './fixtures/variableNameClashes.jsx',
+    true
+  );
+
+  testCode(
+    'should handle import alias spread',
+    './fixtures/aliasSpread.jsx',
+    true
+  );
+
+  testCode('should handle emotion css', './fixtures/emotionCss.jsx', true);
 });

--- a/packages/scripts/scripts/utils/package.js
+++ b/packages/scripts/scripts/utils/package.js
@@ -342,10 +342,24 @@ async function validateLernaDeps() {
   }
 }
 
+function checkEmotionReactDeps(packagePath) {
+  const { dependencies, peerDependencies } = require(packagePath);
+
+  const hasEmotionReactInDependencies = Object.keys(dependencies || {}).some(
+    (key) => key === '@emotion/react'
+  );
+  const hasEmotionReactInPeerDependencies = Object.keys(
+    peerDependencies || {}
+  ).some((key) => key === '@emotion/react');
+
+  return hasEmotionReactInDependencies || hasEmotionReactInPeerDependencies;
+}
+
 module.exports = {
   lintAllPackages,
   processAllPackages,
   evaluatePackage,
   format,
-  validateLernaDeps
+  validateLernaDeps,
+  checkEmotionReactDeps
 };


### PR DESCRIPTION
For projects that do not have "@emotion/react" dependency use default react options for Babel "preset-react" plugin.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/scripts@2.3.6-canary.74.2946446774.0
  # or 
  yarn add @tablecheck/scripts@2.3.6-canary.74.2946446774.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
