### PR TITLE
fix: config issue

### DIFF
--- a/auditjs.json
+++ b/auditjs.json
@@ -871,6 +871,30 @@
           "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2022-4431?component-type=npm&component-name=parse-url&utm_source=auditjs&utm_medium=integration&utm_content=4.0.37"
         }
       ]
+    },
+    {
+      "coordinates": "pkg:npm/parse-url@7.0.2",
+      "description": "An advanced url parser supporting git urls too.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/parse-url@7.0.2?utm_source=auditjs&utm_medium=integration&utm_content=4.0.37",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-2900",
+          "title": "[CVE-2022-2900] CWE-918: Server-Side Request Forgery (SSRF)",
+          "description": "Server-Side Request Forgery (SSRF) in GitHub repository ionicabizau/parse-url prior to 8.1.0.",
+          "cvssScore": 9.1,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N",
+          "cve": "CVE-2022-2900",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-2900?component-type=npm&component-name=parse-url&utm_source=auditjs&utm_medium=integration&utm_content=4.0.37"
+        },
+        {
+          "id": "sonatype-2022-5570",
+          "title": "1 vulnerability found",
+          "description": "1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account",
+          "cvssScore": 9.4,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:H",
+          "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2022-5570"
+        }
+      ]
     }
   ],
   "ignore": [
@@ -1044,6 +1068,12 @@
     },
     {
       "id": "sonatype-2022-4431"
+    },
+    {
+      "id": "CVE-2022-2900"
+    },
+    {
+      "id": "sonatype-2022-5570"
     }
   ]
 }

--- a/packages/scripts/razzle/base.js
+++ b/packages/scripts/razzle/base.js
@@ -88,7 +88,7 @@ module.exports = extendConfig(
 
         webpackConfigDraft.plugins.push(
           new webpack.DefinePlugin({
-            CONFIG: JSON.stringify(config)
+            CONFIG: `(${JSON.stringify(config)})`
           })
         );
         if (userPackage.dependencies && userPackage.dependencies.moment) {


### PR DESCRIPTION
Fixes #76
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/scripts@2.3.7-canary.77.3132920166.0
  # or 
  yarn add @tablecheck/scripts@2.3.7-canary.77.3132920166.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
