### PR TITLE
fix: loosen react dependency versions

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -39,7 +39,7 @@
   },
   "peerDependencies": {
     "eslint": "^8",
-    "react": "^17",
+    "react": ">=17",
     "typescript": "4.x"
   },
   "devDependencies": {

--- a/packages/eslint-config/rules/react.js
+++ b/packages/eslint-config/rules/react.js
@@ -1,49 +1,49 @@
 module.exports = {
-  "react/jsx-wrap-multilines": "off",
-  "react/jsx-one-expression-per-line": "off",
-  "react/jsx-props-no-spreading": "off",
+  'react/jsx-wrap-multilines': 'off',
+  'react/jsx-one-expression-per-line': 'off',
+  'react/jsx-props-no-spreading': 'off',
   // handled by @emotion/babel-preset-css-prop
-  "react/react-in-jsx-scope": "off",
+  'react/react-in-jsx-scope': 'off',
   // No jsx extension: https://github.com/facebook/create-react-app/issues/87#issuecomment-234627904
-  "react/jsx-filename-extension": "off",
+  'react/jsx-filename-extension': 'off',
   // irritating, TS handles this better
-  "react/static-property-placement": "off",
-  "react/prop-types": "off",
+  'react/static-property-placement': 'off',
+  'react/prop-types': 'off',
   // see https://github.com/jsx-eslint/eslint-plugin-react/issues/3384#issuecomment-1236371796
-  "react/no-unknown-property": ["error", { ignore: ["css"] }],
+  'react/no-unknown-property': ['error', { ignore: ['css'] }],
 
   // These cause typing conflicts
-  "react/require-default-props": ["off"],
-  "react/default-props-match-prop-types": [
-    "error",
-    { allowRequiredDefaults: true },
+  'react/require-default-props': ['off'],
+  'react/default-props-match-prop-types': [
+    'error',
+    { allowRequiredDefaults: true }
   ],
 
-  "react/sort-comp": [
-    "error",
+  'react/sort-comp': [
+    'error',
     {
       order: [
-        "static-methods",
-        "instance-variables",
-        "lifecycle",
-        "/^on.+$/",
-        "/^handle.+$/",
-        "getters",
-        "setters",
-        "/^(get|set)(?!(InitialState$|DefaultProps$|ChildContext$)).+$/",
-        "everything-else",
-        "/^render.+$/",
-        "render",
-      ],
-    },
+        'static-methods',
+        'instance-variables',
+        'lifecycle',
+        '/^on.+$/',
+        '/^handle.+$/',
+        'getters',
+        'setters',
+        '/^(get|set)(?!(InitialState$|DefaultProps$|ChildContext$)).+$/',
+        'everything-else',
+        '/^render.+$/',
+        'render'
+      ]
+    }
   ],
-  "react/destructuring-assignment": [
-    "error",
-    "always",
-    { ignoreClassFields: true },
+  'react/destructuring-assignment': [
+    'error',
+    'always',
+    { ignoreClassFields: true }
   ],
-  "react/no-find-dom-node": "error",
-  "react/jsx-fragments": "error",
-  "react/jsx-no-useless-fragment": ["error", { allowExpressions: true }],
-  "@tablecheck/consistent-react-import": "error",
+  'react/no-find-dom-node': 'error',
+  'react/jsx-fragments': 'error',
+  'react/jsx-no-useless-fragment': ['error', { allowExpressions: true }],
+  '@tablecheck/consistent-react-import': 'error'
 };

--- a/packages/eslint-config/rules/react.js
+++ b/packages/eslint-config/rules/react.js
@@ -1,47 +1,49 @@
 module.exports = {
-  'react/jsx-wrap-multilines': 'off',
-  'react/jsx-one-expression-per-line': 'off',
-  'react/jsx-props-no-spreading': 'off',
+  "react/jsx-wrap-multilines": "off",
+  "react/jsx-one-expression-per-line": "off",
+  "react/jsx-props-no-spreading": "off",
   // handled by @emotion/babel-preset-css-prop
-  'react/react-in-jsx-scope': 'off',
+  "react/react-in-jsx-scope": "off",
   // No jsx extension: https://github.com/facebook/create-react-app/issues/87#issuecomment-234627904
-  'react/jsx-filename-extension': 'off',
+  "react/jsx-filename-extension": "off",
   // irritating, TS handles this better
-  'react/static-property-placement': 'off',
-  'react/prop-types': 'off',
+  "react/static-property-placement": "off",
+  "react/prop-types": "off",
+  // see https://github.com/jsx-eslint/eslint-plugin-react/issues/3384#issuecomment-1236371796
+  "react/no-unknown-property": ["error", { ignore: ["css"] }],
 
   // These cause typing conflicts
-  'react/require-default-props': ['off'],
-  'react/default-props-match-prop-types': [
-    'error',
-    { allowRequiredDefaults: true }
+  "react/require-default-props": ["off"],
+  "react/default-props-match-prop-types": [
+    "error",
+    { allowRequiredDefaults: true },
   ],
 
-  'react/sort-comp': [
-    'error',
+  "react/sort-comp": [
+    "error",
     {
       order: [
-        'static-methods',
-        'instance-variables',
-        'lifecycle',
-        '/^on.+$/',
-        '/^handle.+$/',
-        'getters',
-        'setters',
-        '/^(get|set)(?!(InitialState$|DefaultProps$|ChildContext$)).+$/',
-        'everything-else',
-        '/^render.+$/',
-        'render'
-      ]
-    }
+        "static-methods",
+        "instance-variables",
+        "lifecycle",
+        "/^on.+$/",
+        "/^handle.+$/",
+        "getters",
+        "setters",
+        "/^(get|set)(?!(InitialState$|DefaultProps$|ChildContext$)).+$/",
+        "everything-else",
+        "/^render.+$/",
+        "render",
+      ],
+    },
   ],
-  'react/destructuring-assignment': [
-    'error',
-    'always',
-    { ignoreClassFields: true }
+  "react/destructuring-assignment": [
+    "error",
+    "always",
+    { ignoreClassFields: true },
   ],
-  'react/no-find-dom-node': 'error',
-  'react/jsx-fragments': 'error',
-  'react/jsx-no-useless-fragment': ['error', { allowExpressions: true }],
-  '@tablecheck/consistent-react-import': 'error'
+  "react/no-find-dom-node": "error",
+  "react/jsx-fragments": "error",
+  "react/jsx-no-useless-fragment": ["error", { allowExpressions: true }],
+  "@tablecheck/consistent-react-import": "error",
 };

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -36,8 +36,8 @@
     "mini-css-extract-plugin": "^1",
     "razzle": "^4.2.17",
     "razzle-dev-utils": "^4.1.0",
-    "react": "^17",
-    "react-dom": "^17",
+    "react": ">=17",
+    "react-dom": ">=17",
     "storybook": "^6.5.10"
   },
   "dependencies": {


### PR DESCRIPTION
There are probably other changes that need to be taken to support react 18 fully, but most of it should work with current setup. Other changes will be done in next branch but this at least allows us to try out react 18 without the CI failing.

Specifically related to the TableKit next branch which has some installation issues due to this - canary version was tested here: https://github.com/tablecheck/tablekit/pull/131
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/eslint-config@1.8.2-canary.78.3156990612.0
  npm install @tablecheck/scripts@2.3.8-canary.78.3156990612.0
  # or 
  yarn add @tablecheck/eslint-config@1.8.2-canary.78.3156990612.0
  yarn add @tablecheck/scripts@2.3.8-canary.78.3156990612.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
