### PR TITLE
fix(scripts): correct path matcher regex for stripping lib types

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install and Build 🔧
         run: |
-          npm ci --legacy-peer-deps
+          npm ci
           npm run build
 
       - name: Deploy 🚀

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: ${{ steps.nvm.outputs.nvmrc }}
 
       - name: Install 🔧
-        run: npm ci --legacy-peer-deps
+        run: npm ci
 
   lint:
     needs: [setup]
@@ -45,7 +45,7 @@ jobs:
           node-version: ${{ needs.setup.outputs.nvmrc }}
 
       - name: Restore npm installs and Lerna setup
-        run: npm ci --legacy-peer-deps
+        run: npm ci
 
       - name: Validate all commits from PR
         run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
@@ -66,7 +66,7 @@ jobs:
           node-version: ${{ needs.setup.outputs.nvmrc }}
 
       - name: Restore npm installs and Lerna setup
-        run: npm ci --legacy-peer-deps
+        run: npm ci
 
       - name: Audit Dependencies
         run: npm run audit:ci
@@ -87,7 +87,7 @@ jobs:
           node-version: ${{ needs.setup.outputs.nvmrc }}
 
       - name: Restore npm installs and Lerna setup
-        run: npm ci --legacy-peer-deps
+        run: npm ci
 
       - name: Run Tests
         run: npm test
@@ -118,7 +118,7 @@ jobs:
           node-version: ${{ steps.nvm.outputs.nvmrc }}
 
       - name: Install 🔧
-        run: npm ci --legacy-peer-deps
+        run: npm ci
 
       - name: Create Canary Release ✨
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           cache: npm
 
       - name: Install 🔧
-        run: npm ci --legacy-peer-deps
+        run: npm ci
 
       - name: Run Tests
         run: npm test

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To setup your development environment please run these commands in order. We dev
 
 ```shell
 nvm use
-npm ci --legacy-peer-deps
+npm ci
 npm start
 ```
 

--- a/auditjs.json
+++ b/auditjs.json
@@ -895,6 +895,148 @@
           "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2022-5570"
         }
       ]
+    },
+    {
+      "coordinates": "pkg:npm/loader-utils@2.0.2",
+      "description": "utils for webpack loaders",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/loader-utils@2.0.2?utm_source=auditjs&utm_medium=integration&utm_content=4.0.37",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-37601",
+          "title": "[CVE-2022-37601] Prototype pollution vulnerability in function parseQuery in parseQuery.js in webpack loader-utils 2.0.0 via the name variable in parseQuery.js.",
+          "description": "Prototype pollution vulnerability in function parseQuery in parseQuery.js in webpack loader-utils 2.0.0 via the name variable in parseQuery.js.",
+          "cvssScore": 9.8,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "cve": "CVE-2022-37601",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-37601?component-type=npm&component-name=loader-utils&utm_source=auditjs&utm_medium=integration&utm_content=4.0.37"
+        },
+        {
+          "id": "CVE-2022-37599",
+          "title": "[CVE-2022-37599] CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')",
+          "description": "A Regular expression denial of service (ReDoS) flaw was found in Function interpolateName in interpolateName.js in webpack loader-utils 2.0.0 via the resourcePath variable in interpolateName.js.",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2022-37599",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-37599?component-type=npm&component-name=loader-utils&utm_source=auditjs&utm_medium=integration&utm_content=4.0.37"
+        },
+        {
+          "id": "CVE-2022-37603",
+          "title": "[CVE-2022-37603] A Regular expression denial of service (ReDoS) flaw was found in Function interpolateName in interpolateName.js in webpack loader-utils 2.0.0 via the url variable in interpolateName.js.",
+          "description": "A Regular expression denial of service (ReDoS) flaw was found in Function interpolateName in interpolateName.js in webpack loader-utils 2.0.0 via the url variable in interpolateName.js.",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2022-37603",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-37603?component-type=npm&component-name=loader-utils&utm_source=auditjs&utm_medium=integration&utm_content=4.0.37"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/loader-utils@1.4.0",
+      "description": "utils for webpack loaders",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/loader-utils@1.4.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.37",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-37601",
+          "title": "[CVE-2022-37601] Prototype pollution vulnerability in function parseQuery in parseQuery.js in webpack loader-utils 2.0.0 via the name variable in parseQuery.js.",
+          "description": "Prototype pollution vulnerability in function parseQuery in parseQuery.js in webpack loader-utils 2.0.0 via the name variable in parseQuery.js.",
+          "cvssScore": 9.8,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "cve": "CVE-2022-37601",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-37601?component-type=npm&component-name=loader-utils&utm_source=auditjs&utm_medium=integration&utm_content=4.0.37"
+        },
+        {
+          "id": "CVE-2022-37599",
+          "title": "[CVE-2022-37599] CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')",
+          "description": "A Regular expression denial of service (ReDoS) flaw was found in Function interpolateName in interpolateName.js in webpack loader-utils 2.0.0 via the resourcePath variable in interpolateName.js.",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2022-37599",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-37599?component-type=npm&component-name=loader-utils&utm_source=auditjs&utm_medium=integration&utm_content=4.0.37"
+        },
+        {
+          "id": "CVE-2022-37603",
+          "title": "[CVE-2022-37603] A Regular expression denial of service (ReDoS) flaw was found in Function interpolateName in interpolateName.js in webpack loader-utils 2.0.0 via the url variable in interpolateName.js.",
+          "description": "A Regular expression denial of service (ReDoS) flaw was found in Function interpolateName in interpolateName.js in webpack loader-utils 2.0.0 via the url variable in interpolateName.js.",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2022-37603",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-37603?component-type=npm&component-name=loader-utils&utm_source=auditjs&utm_medium=integration&utm_content=4.0.37"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/%40xmldom/xmldom@0.7.5",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/%40xmldom/xmldom@0.7.5?utm_source=auditjs&utm_medium=integration&utm_content=4.0.37",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-37616",
+          "title": "[CVE-2022-37616] ** DISPUTED ** A prototype pollution vulnerability exists in the function copy in dom.js in the xmldom (published as @xmldom/xmldom) package before 0.8.3 for Node.js via the p variable. NOTE: the vendor states \"we are in the process of marking this report as invalid.\"",
+          "description": "** DISPUTED ** A prototype pollution vulnerability exists in the function copy in dom.js in the xmldom (published as @xmldom/xmldom) package before 0.8.3 for Node.js via the p variable. NOTE: the vendor states \"we are in the process of marking this report as invalid.\"",
+          "cvssScore": 9.8,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "cve": "CVE-2022-37616",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-37616?component-type=npm&component-name=%40xmldom%2Fxmldom&utm_source=auditjs&utm_medium=integration&utm_content=4.0.37"
+        },
+        {
+          "id": "CVE-2022-39353",
+          "title": "[CVE-2022-39353] CWE-20: Improper Input Validation",
+          "description": "xmldom is a pure JavaScript W3C standard-based (XML DOM Level 2 Core) `DOMParser` and `XMLSerializer` module. xmldom parses XML that is not well-formed because it contains multiple top level elements, and adds all root nodes to the `childNodes` collection of the `Document`, without reporting any error or throwing. This breaks the assumption that there is only a single root node in the tree, which led to issuance of CVE-2022-39299 as it is a potential issue for dependents. Update to @xmldom/xmldom@~0.7.7, @xmldom/xmldom@~0.8.4 (dist-tag latest) or @xmldom/xmldom@>=0.9.0-beta.4 (dist-tag next). As a workaround, please one of the following approaches depending on your use case: instead of searching for elements in the whole DOM, only search in the `documentElement`or reject a document with a document that has more then 1 `childNode`.",
+          "cvssScore": 9.8,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "cve": "CVE-2022-39353",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-39353?component-type=npm&component-name=%40xmldom%2Fxmldom&utm_source=auditjs&utm_medium=integration&utm_content=4.0.37"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/css-what@3.4.2",
+      "description": "a CSS selector parser",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/css-what@3.4.2?utm_source=auditjs&utm_medium=integration&utm_content=4.0.37",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-21222",
+          "title": "[CVE-2022-21222] CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')",
+          "description": "The package css-what before 2.1.3 are vulnerable to Regular Expression Denial of Service (ReDoS) due to the usage of insecure regular expression in the re_attr variable of index.js. The exploitation of this vulnerability could be triggered via the parse function.",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2022-21222",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-21222?component-type=npm&component-name=css-what&utm_source=auditjs&utm_medium=integration&utm_content=4.0.37"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/loader-utils@2.0.0",
+      "description": "utils for webpack loaders",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/loader-utils@2.0.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.37",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-37601",
+          "title": "[CVE-2022-37601] Prototype pollution vulnerability in function parseQuery in parseQuery.js in webpack loader-utils 2.0.0 via the name variable in parseQuery.js.",
+          "description": "Prototype pollution vulnerability in function parseQuery in parseQuery.js in webpack loader-utils 2.0.0 via the name variable in parseQuery.js.",
+          "cvssScore": 9.8,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "cve": "CVE-2022-37601",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-37601?component-type=npm&component-name=loader-utils&utm_source=auditjs&utm_medium=integration&utm_content=4.0.37"
+        },
+        {
+          "id": "CVE-2022-37599",
+          "title": "[CVE-2022-37599] CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')",
+          "description": "A Regular expression denial of service (ReDoS) flaw was found in Function interpolateName in interpolateName.js in webpack loader-utils 2.0.0 via the resourcePath variable in interpolateName.js.",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2022-37599",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-37599?component-type=npm&component-name=loader-utils&utm_source=auditjs&utm_medium=integration&utm_content=4.0.37"
+        },
+        {
+          "id": "CVE-2022-37603",
+          "title": "[CVE-2022-37603] A Regular expression denial of service (ReDoS) flaw was found in Function interpolateName in interpolateName.js in webpack loader-utils 2.0.0 via the url variable in interpolateName.js.",
+          "description": "A Regular expression denial of service (ReDoS) flaw was found in Function interpolateName in interpolateName.js in webpack loader-utils 2.0.0 via the url variable in interpolateName.js.",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2022-37603",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-37603?component-type=npm&component-name=loader-utils&utm_source=auditjs&utm_medium=integration&utm_content=4.0.37"
+        }
+      ]
     }
   ],
   "ignore": [
@@ -1074,6 +1216,24 @@
     },
     {
       "id": "sonatype-2022-5570"
+    },
+    {
+      "id": "CVE-2022-37601"
+    },
+    {
+      "id": "CVE-2022-37599"
+    },
+    {
+      "id": "CVE-2022-37603"
+    },
+    {
+      "id": "CVE-2022-37616"
+    },
+    {
+      "id": "CVE-2022-39353"
+    },
+    {
+      "id": "CVE-2022-21222"
     }
   ]
 }

--- a/packages/scripts/scripts/rollup/buildPackage.js
+++ b/packages/scripts/scripts/rollup/buildPackage.js
@@ -385,7 +385,7 @@ async function buildPackage(libConfigPath, rootConfigPath) {
     const pathMatchers = pathKeys.map((key) => (relativePath) => {
       if (
         !relativePath.match(
-          new RegExp(`^${key.replace(/[*/]*$/gi, '.*')}`, 'ig')
+          new RegExp(`^${key.replace(/[*/]+?$/gi, '($|/).*')}`, 'ig')
         )
       )
         return false;


### PR DESCRIPTION
See this replay for the bug reproduction and comments https://app.replay.io/recording/replay-of-build-libjs--e54917c4-0962-4cbf-976f-f8ecae32ee91

New Resulting Regex;
![CleanShot 2022-11-16 at 09 58 54](https://user-images.githubusercontent.com/1085899/202057766-635fd86c-775e-4984-a82f-34fc47a71050.png)

Replace regex comparison;
![CleanShot 2022-11-16 at 10 04 59](https://user-images.githubusercontent.com/1085899/202058138-0a35e0cd-48ba-408a-99e3-6e5a61dc3b4c.png)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/scripts@2.3.9-canary.80.3475811983.0
  # or 
  yarn add @tablecheck/scripts@2.3.9-canary.80.3475811983.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
