### PR TITLE
fix: lib-build correctly remaps root level absolute file imports

### DIFF
--- a/auditjs.json
+++ b/auditjs.json
@@ -1037,6 +1037,117 @@
           "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-37603?component-type=npm&component-name=loader-utils&utm_source=auditjs&utm_medium=integration&utm_content=4.0.37"
         }
       ]
+    },
+    {
+      "coordinates": "pkg:npm/json5@2.2.1",
+      "description": "JSON for humans.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/json5@2.2.1?utm_source=auditjs&utm_medium=integration&utm_content=4.0.37",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-46175",
+          "title": "[CVE-2022-46175] CWE-1321",
+          "description": "JSON5 is an extension to the popular JSON file format that aims to be easier to write and maintain by hand (e.g. for config files). The `parse` method of the JSON5 library before and including versions 1.0.1 and 2.2.1 does not restrict parsing of keys named `__proto__`, allowing specially crafted strings to pollute the prototype of the resulting object. This vulnerability pollutes the prototype of the object returned by `JSON5.parse` and not the global Object prototype, which is the commonly understood definition of Prototype Pollution. However, polluting the prototype of a single object can have significant security impact for an application if the object is later used in trusted operations. This vulnerability could allow an attacker to set arbitrary and unexpected keys on the object returned from `JSON5.parse`. The actual impact will depend on how applications utilize the returned object and how they filter unwanted keys, but could include denial of service, cross-site scripting, elevation of privilege, and in extreme cases, remote code execution. `JSON5.parse` should restrict parsing of `__proto__` keys when parsing JSON strings to objects. As a point of reference, the `JSON.parse` method included in JavaScript ignores `__proto__` keys. Simply changing `JSON5.parse` to `JSON.parse` in the examples above mitigates this vulnerability. This vulnerability is patched in json5 versions 1.0.2, 2.2.2, and later.\n\nSonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2022-46175 for details",
+          "cvssScore": 8.8,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+          "cve": "CVE-2022-46175",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-46175?component-type=npm&component-name=json5&utm_source=auditjs&utm_medium=integration&utm_content=4.0.37"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/decode-uri-component@0.2.0",
+      "description": "A better decodeURIComponent",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/decode-uri-component@0.2.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.37",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-38900",
+          "title": "[CVE-2022-38900] CWE-20: Improper Input Validation",
+          "description": "decode-uri-component 0.2.0 is vulnerable to Improper Input Validation resulting in DoS.",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2022-38900",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-38900?component-type=npm&component-name=decode-uri-component&utm_source=auditjs&utm_medium=integration&utm_content=4.0.37"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/core-js@3.23.3",
+      "description": "Standard library",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/core-js@3.23.3?utm_source=auditjs&utm_medium=integration&utm_content=4.0.37",
+      "vulnerabilities": [
+        {
+          "id": "sonatype-2023-0962",
+          "title": "[sonatype-2023-0962] Unknown",
+          "description": "core-js - Regular expression Denial of Service (ReDoS)\n\ncore-js - Regular expression Denial of Service (ReDoS)",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "reference": "https://ossindex.sonatype.org/vulnerability/sonatype-2023-0962?component-type=npm&component-name=core-js&utm_source=auditjs&utm_medium=integration&utm_content=4.0.37"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/http-cache-semantics@4.1.0",
+      "description": "Parses Cache-Control and other headers. Helps building correct HTTP caches and proxies",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/http-cache-semantics@4.1.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.37",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-25881",
+          "title": "[CVE-2022-25881] CWE-1333",
+          "description": "This affects versions of the package http-cache-semantics before 4.1.1. The issue can be exploited via malicious request header values sent to a server, when that server reads the cache policy from the request using this library.",
+          "cvssScore": 7.5,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cve": "CVE-2022-25881",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-25881?component-type=npm&component-name=http-cache-semantics&utm_source=auditjs&utm_medium=integration&utm_content=4.0.37"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/json5@1.0.1",
+      "description": "JSON for humans.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/json5@1.0.1?utm_source=auditjs&utm_medium=integration&utm_content=4.0.37",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2022-46175",
+          "title": "[CVE-2022-46175] CWE-1321",
+          "description": "JSON5 is an extension to the popular JSON file format that aims to be easier to write and maintain by hand (e.g. for config files). The `parse` method of the JSON5 library before and including versions 1.0.1 and 2.2.1 does not restrict parsing of keys named `__proto__`, allowing specially crafted strings to pollute the prototype of the resulting object. This vulnerability pollutes the prototype of the object returned by `JSON5.parse` and not the global Object prototype, which is the commonly understood definition of Prototype Pollution. However, polluting the prototype of a single object can have significant security impact for an application if the object is later used in trusted operations. This vulnerability could allow an attacker to set arbitrary and unexpected keys on the object returned from `JSON5.parse`. The actual impact will depend on how applications utilize the returned object and how they filter unwanted keys, but could include denial of service, cross-site scripting, elevation of privilege, and in extreme cases, remote code execution. `JSON5.parse` should restrict parsing of `__proto__` keys when parsing JSON strings to objects. As a point of reference, the `JSON.parse` method included in JavaScript ignores `__proto__` keys. Simply changing `JSON5.parse` to `JSON.parse` in the examples above mitigates this vulnerability. This vulnerability is patched in json5 versions 1.0.2, 2.2.2, and later.\n\nSonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2022-46175 for details",
+          "cvssScore": 8.8,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+          "cve": "CVE-2022-46175",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-46175?component-type=npm&component-name=json5&utm_source=auditjs&utm_medium=integration&utm_content=4.0.37"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/webpack@4.46.0",
+      "description": "Packs CommonJs/AMD modules for the browser. Allows to split your codebase into multiple bundles, which can be loaded on demand. Support loaders to preprocess files, i.e. json, jsx, es7, css, less, ... and your custom stuff.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/webpack@4.46.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.37",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2023-28154",
+          "title": "[CVE-2023-28154] CWE-noinfo",
+          "description": "Webpack 5 before 5.76.0 does not avoid cross-realm object access. ImportParserPlugin.js mishandles the magic comment feature. An attacker who controls a property of an untrusted object can obtain access to the real global object.\n\nSonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2023-28154 for details",
+          "cvssScore": 9.8,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "cve": "CVE-2023-28154",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2023-28154?component-type=npm&component-name=webpack&utm_source=auditjs&utm_medium=integration&utm_content=4.0.37"
+        }
+      ]
+    },
+    {
+      "coordinates": "pkg:npm/request@2.88.2",
+      "description": "Simplified HTTP request client.",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/request@2.88.2?utm_source=auditjs&utm_medium=integration&utm_content=4.0.37",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2023-28155",
+          "title": "[CVE-2023-28155] CWE-918: Server-Side Request Forgery (SSRF)",
+          "description": "** UNSUPPORTED WHEN ASSIGNED ** The Request package through 2.88.1 for Node.js allows a bypass of SSRF mitigations via an attacker-controller server that does a cross-protocol redirect (HTTP to HTTPS, or HTTPS to HTTP). NOTE: This vulnerability only affects products that are no longer supported by the maintainer.",
+          "cvssScore": 6.1,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+          "cve": "CVE-2023-28155",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2023-28155?component-type=npm&component-name=request&utm_source=auditjs&utm_medium=integration&utm_content=4.0.37"
+        }
+      ]
     }
   ],
   "ignore": [
@@ -1234,6 +1345,24 @@
     },
     {
       "id": "CVE-2022-21222"
+    },
+    {
+      "id": "CVE-2022-46175"
+    },
+    {
+      "id": "CVE-2022-38900"
+    },
+    {
+      "id": "sonatype-2023-0962"
+    },
+    {
+      "id": "CVE-2022-25881"
+    },
+    {
+      "id": "CVE-2023-28154"
+    },
+    {
+      "id": "CVE-2023-28155"
     }
   ]
 }

--- a/packages/scripts/scripts/rollup/buildPackage.js
+++ b/packages/scripts/scripts/rollup/buildPackage.js
@@ -378,8 +378,8 @@ async function buildPackage(libConfigPath, rootConfigPath) {
       fs.readdirSync(path.join(packageDirectory, baseUrl), {
         withFileTypes: true
       }).forEach((dirent) => {
-        if (!dirent.isDirectory()) return;
-        pathKeys.push(`${dirent.name}/*`);
+        if (dirent.isDirectory()) pathKeys.push(`${dirent.name}/*`);
+        else pathKeys.push(dirent.name.split('.').slice(0, -1).join('.'));
       });
     }
     const pathMatchers = pathKeys.map((key) => (relativePath) => {


### PR DESCRIPTION
This fixes absolute imports to files in the `.d.ts` output files which do not support file aliases, only relative imports.

```ts
// in file `src/foo/bar/sub.ts
import { a } from 'rootIndexFile';
// should be rewritten to the following
import { a } from '../../rootIndexFile';
```
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/scripts@2.3.10-canary.81.4499279437.0
  # or 
  yarn add @tablecheck/scripts@2.3.10-canary.81.4499279437.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
