### PR TITLE
ci: fix nx branch setup

### DIFF
--- a/.github/setup/action.yml
+++ b/.github/setup/action.yml
@@ -19,7 +19,7 @@ runs:
     - name: Read .nvmrc
       shell: bash
       id: nvm
-      run: echo "::set-output name=nvmrc::$(cat .nvmrc)"
+      run: echo "nvmrc=$(cat .nvmrc)" >> $GITHUB_OUTPUT
 
     - name: Setup Node.js
       uses: actions/setup-node@v2
@@ -27,8 +27,14 @@ runs:
         node-version: ${{ steps.nvm.outputs.nvmrc }}
         cache: npm
 
-    - name: Setup branch for NX
+    - name: Setup branch for NX (main)
       shell: bash
+      if: github.ref == 'refs/head/main'
+      run: git branch -u origin/main main
+
+    - name: Setup branch for NX (!main)
+      shell: bash
+      if: github.ref != 'refs/head/main'
       run: git branch --track main origin/main
 
     - name: Install without scripts 🔧

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Read .nvmrc
         id: nvm
-        run: echo ::set-output name=nvmrc::$(cat .nvmrc)
+        run: echo "nvmrc=$(cat .nvmrc)" >> $GITHUB_OUTPUT
 
       - name: Setup Node.js
         uses: actions/setup-node@v2

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -10,16 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout 🛎️
-        uses: actions/checkout@v2
-
-      - uses: ./.github/setup
-
   checks:
-    needs: [setup]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
@@ -40,7 +31,6 @@ jobs:
           OSSI_TOKEN: ${{ secrets.OSSI_TOKEN }}
 
   test:
-    needs: [setup]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
@@ -55,7 +45,7 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@v1
         if: always()
         with:
-          files: junit/**/*.xml
+          files: coverage/**/*.junit.xml
 
   release:
     runs-on: ubuntu-latest
@@ -64,6 +54,8 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - uses: ./.github/setup
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
 
       - uses: ./.github/setup
 

--- a/nx.json
+++ b/nx.json
@@ -10,8 +10,9 @@
   },
   "targetDefaults": {
     "build": {
-      "dependsOn": ["prepare", "^build"],
-      "inputs": ["default", "^default", "baseTypescript"]
+      "dependsOn": ["^build"],
+      "inputs": ["default", "^default", "baseTypescript"],
+      "outputs": ["{projectRoot}/dist"]
     },
     "test": {
       "dependsOn": ["^test"],

--- a/packages/eslint-plugin/project.json
+++ b/packages/eslint-plugin/project.json
@@ -23,6 +23,8 @@
       "executor": "@nx/vite:test",
       "outputs": ["{workspaceRoot}/coverage/packages/eslint-plugin"],
       "options": {
+        "coverage": true,
+        "reporters": ["junit"],
         "passWithNoTests": true,
         "reportsDirectory": "../../coverage/packages/eslint-plugin"
       }

--- a/packages/eslint-plugin/vite.config.ts
+++ b/packages/eslint-plugin/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
 
   test: {
     globals: true,
+    outputFile: '../../coverage/packages/eslint-plugin/report.junit.xml',
     cache: {
       dir: '../../node_modules/.vitest',
     },


### PR DESCRIPTION
* properly cache the result of tests so the same junit file is output and reported to the PR (requires vite config and nx config)
* cache build outputs so they can be restored

See https://github.com/tablecheck/tablecheck-react-system/actions/runs/6336490202/job/17209658997 (major label just in case as the last one failed to release)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/frontend-audit@2.0.0-canary.84.6337128203.0
  npm install @tablecheck/commitlint-config@2.0.0-canary.84.6337128203.0
  npm install @tablecheck/eslint-config@2.0.0-canary.84.6337128203.0
  npm install @tablecheck/eslint-plugin@2.0.0-canary.84.6337128203.0
  npm install @tablecheck/nx@2.0.0-canary.84.6337128203.0
  npm install @tablecheck/prettier-config@2.0.0-canary.84.6337128203.0
  npm install @tablecheck/semantic-release-config@3.0.0-canary.84.6337128203.0
  npm install @tablecheck/frontend-utils@3.0.0-canary.84.6337128203.0
  # or 
  yarn add @tablecheck/frontend-audit@2.0.0-canary.84.6337128203.0
  yarn add @tablecheck/commitlint-config@2.0.0-canary.84.6337128203.0
  yarn add @tablecheck/eslint-config@2.0.0-canary.84.6337128203.0
  yarn add @tablecheck/eslint-plugin@2.0.0-canary.84.6337128203.0
  yarn add @tablecheck/nx@2.0.0-canary.84.6337128203.0
  yarn add @tablecheck/prettier-config@2.0.0-canary.84.6337128203.0
  yarn add @tablecheck/semantic-release-config@3.0.0-canary.84.6337128203.0
  yarn add @tablecheck/frontend-utils@3.0.0-canary.84.6337128203.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
