### PR TITLE
ci: fix NX branch setup

### DIFF
--- a/.github/setup/action.yml
+++ b/.github/setup/action.yml
@@ -29,12 +29,12 @@ runs:
 
     - name: Setup branch for NX (main)
       shell: bash
-      if: github.ref == 'refs/head/main'
+      if: github.ref == 'refs/heads/main'
       run: git branch -u origin/main main
 
     - name: Setup branch for NX (!main)
       shell: bash
-      if: github.ref != 'refs/head/main'
+      if: github.ref != 'refs/heads/main'
       run: git branch --track main origin/main
 
     - name: Install without scripts 🔧


### PR DESCRIPTION
Apparently I missed an 's' - https://stackoverflow.com/questions/58139406/only-run-job-on-specific-branch-with-github-actions

https://github.com/tablecheck/tablecheck-react-system/actions/runs/6353515366/job/17258365323