### PR TITLE
fix: eslint needs extra configs to resolve paths correctly

### DIFF
--- a/.github/setup/action.yml
+++ b/.github/setup/action.yml
@@ -29,12 +29,12 @@ runs:
 
     - name: Setup branch for NX (main)
       shell: bash
-      if: github.ref == 'refs/head/main'
+      if: github.ref == 'refs/heads/main'
       run: git branch -u origin/main main
 
     - name: Setup branch for NX (!main)
       shell: bash
-      if: github.ref != 'refs/head/main'
+      if: github.ref != 'refs/heads/main'
       run: git branch --track main origin/main
 
     - name: Install without scripts 🔧
@@ -43,4 +43,4 @@ runs:
 
     - name: Build 🔨
       shell: bash
-      run: npm run build
+      run: npm run build:ci

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           git branch --track main origin/main
           npm ci --prefer-offline --silent
-          npm run build
+          npm run build:ci
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,6 @@ jobs:
 
       - uses: ./.github/setup
 
-      - name: Build
-        run: npm run build
-
       - name: Run Tests
         run: npm test
 

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
     "test:watch": "nx run-many --target=test:watch",
     "start": "start-storybook -p 6006",
     "build": "nx affected --target=build",
+    "build:ci": "nx run-many --target=build",
     "build:docs": "build-storybook",
-    "prepare": "husky install && npm run build",
+    "prepare": "husky install && npm run build:ci",
     "all-upgrade": "npm-upgrade && lerna exec --concurrency 1 -- npm-upgrade"
   },
   "workspaces": [

--- a/packages/eslint-config/src/overrides/buildBaseTypescript.ts
+++ b/packages/eslint-config/src/overrides/buildBaseTypescript.ts
@@ -82,6 +82,7 @@ export function buildBaseTypescript(
           },
         },
       ],
+      '@tablecheck/prefer-shortest-import': 'error',
       ...forcedRules,
     },
   };

--- a/packages/eslint-plugin/__tests__/shortestImport.test.ts
+++ b/packages/eslint-plugin/__tests__/shortestImport.test.ts
@@ -94,6 +94,14 @@ ruleTester.run('shortestImport', rule, {
       path: '~/feature1/slice2/second',
       filename: './test_src/feature1/slice1/inner1/index.ts',
     },
+    {
+      path: '@node/module',
+      filename: './test_src/feature1/slice1/inner1/index.ts',
+    },
+    {
+      path: 'react',
+      filename: './test_src/feature1/slice1/inner1/index.ts',
+    },
   ]),
   invalid: convertPathCaseToCodeCase([
     {

--- a/packages/eslint-plugin/src/shortestImport.ts
+++ b/packages/eslint-plugin/src/shortestImport.ts
@@ -148,10 +148,20 @@ export const shortestImport: TSESLint.RuleModule<
       return relativeLength <= aliasLength;
     }
 
+    function isImportNodeModule(importPath: string) {
+      if (importPath.startsWith('@')) return true;
+      const isPathMapping = Object.keys(pathMappings).some((key) =>
+        importPath.startsWith(key),
+      );
+      if (isPathMapping) return false;
+      return !importPath.startsWith('.') && !importPath.startsWith('/');
+    }
+
     function checkAndFixImport(node: ImportExpression | ImportDeclaration) {
       if (node.source.type !== AST_NODE_TYPES.Literal) return;
       const importPath = node.source.value;
-      if (typeof importPath !== 'string') return;
+      if (typeof importPath !== 'string' || isImportNodeModule(importPath))
+        return;
       const resolvedImport = resolveImport(importPath);
       const relativePath = getRelativeImport(importPath, resolvedImport);
       const aliasPath = getPathAliasImport(resolvedImport);

--- a/packages/nx/src/generators/quality/eslintConfig.ts
+++ b/packages/nx/src/generators/quality/eslintConfig.ts
@@ -1,0 +1,43 @@
+import * as path from 'path';
+
+import { Tree } from '@nx/devkit';
+import { getNxProjectRoot, outputPrettyFile } from '@tablecheck/frontend-utils';
+import * as fs from 'fs-extra';
+
+function getConfigs(projectRoot: string) {
+  const mapToPath = (filename: string) => path.join(projectRoot, filename);
+  const nxAppConfigs = ['tsconfig.app.json', 'tsconfig.spec.json'].map(
+    mapToPath,
+  );
+  const defaultConfigs = ['tsconfig.base.json', 'tsconfig.json'].map(mapToPath);
+  if (nxAppConfigs.every((config) => fs.existsSync(config))) {
+    return nxAppConfigs;
+  }
+  return defaultConfigs.filter((config) => fs.existsSync(config));
+}
+
+export function generateEslintConfig(tree: Tree, projectName: string) {
+  const { projectRoot } = getNxProjectRoot(tree, projectName);
+  const projectTsConfigs =
+    getConfigs(projectRoot)
+      .map((tsConfig) => path.relative(tree.root, tsConfig))
+      .join(',') ||
+    '/* could not detect tsconfig.json files, manually set them here */';
+  const fileContent = `
+module.exports = {
+    extends: ['@tablecheck/eslint-config'],
+    parserOptions: {
+        project: [${projectTsConfigs}],
+    },
+    settings: {
+      'import/resolver': {
+          typescript: {
+              project: [${projectTsConfigs}],
+            },
+        },
+    },
+    rules: {},
+};
+`;
+  outputPrettyFile(path.join(projectRoot, '.eslintrc.cjs'), fileContent);
+}

--- a/packages/nx/src/generators/quality/files/.eslintrc.cjs
+++ b/packages/nx/src/generators/quality/files/.eslintrc.cjs
@@ -1,7 +1,0 @@
-module.exports = {
-  extends: ['@tablecheck/eslint-config'],
-  parserOptions: {
-    project: './tsconfig.json',
-  },
-  rules: {},
-};

--- a/packages/nx/src/generators/quality/projectConfig.ts
+++ b/packages/nx/src/generators/quality/projectConfig.ts
@@ -1,0 +1,61 @@
+import * as path from 'path';
+
+import {
+  Tree,
+  addProjectConfiguration,
+  readProjectConfiguration,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+import { getNxProjectRoot } from '@tablecheck/frontend-utils';
+import merge from 'lodash/merge';
+
+export function updateProjectConfig(tree: Tree, projectName: string) {
+  const { projectSourceRoot, projectRoot } = getNxProjectRoot(
+    tree,
+    projectName,
+  );
+  const lintTarget = {
+    executor: '@tablecheck/nx:quality',
+    outputs: ['{options.outputFile}'],
+    options: {
+      lintFilePatterns: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'].map(
+        (pattern) =>
+          path.join(
+            '{projectRoot}',
+            path.relative(projectRoot, path.join(projectSourceRoot, pattern)),
+          ),
+      ),
+    },
+  };
+  const lintFormatTarget = merge({}, lintTarget, {
+    options: {
+      fix: true,
+    },
+  });
+  try {
+    const projectConfig = readProjectConfiguration(tree, projectName);
+    updateProjectConfiguration(
+      tree,
+      projectName,
+      merge(projectConfig, {
+        targets: {
+          quality: lintTarget,
+          'quality:format': lintFormatTarget,
+        },
+      }),
+    );
+  } catch (e) {
+    console.error(
+      'Failed to detect existing project config, generating new project.json to run executors',
+      e,
+    );
+    addProjectConfiguration(tree, projectName, {
+      root: '.',
+      sourceRoot: 'src',
+      targets: {
+        quality: lintTarget,
+        'quality:format': lintFormatTarget,
+      },
+    });
+  }
+}


### PR DESCRIPTION
Merged the release CI fixes from another branch here as I didn't figure out that one just needed the `npm run build:ci` changes to run properly 🤦 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/frontend-audit@2.0.0-canary.86.6377429546.0
  npm install @tablecheck/commitlint-config@2.0.0-canary.86.6377429546.0
  npm install @tablecheck/eslint-config@2.0.0-canary.86.6377429546.0
  npm install @tablecheck/eslint-plugin@2.0.0-canary.86.6377429546.0
  npm install @tablecheck/nx@2.0.0-canary.86.6377429546.0
  npm install @tablecheck/prettier-config@2.0.0-canary.86.6377429546.0
  npm install @tablecheck/semantic-release-config@3.0.0-canary.86.6377429546.0
  npm install @tablecheck/frontend-utils@3.0.0-canary.86.6377429546.0
  # or 
  yarn add @tablecheck/frontend-audit@2.0.0-canary.86.6377429546.0
  yarn add @tablecheck/commitlint-config@2.0.0-canary.86.6377429546.0
  yarn add @tablecheck/eslint-config@2.0.0-canary.86.6377429546.0
  yarn add @tablecheck/eslint-plugin@2.0.0-canary.86.6377429546.0
  yarn add @tablecheck/nx@2.0.0-canary.86.6377429546.0
  yarn add @tablecheck/prettier-config@2.0.0-canary.86.6377429546.0
  yarn add @tablecheck/semantic-release-config@3.0.0-canary.86.6377429546.0
  yarn add @tablecheck/frontend-utils@3.0.0-canary.86.6377429546.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
