### PR TITLE
fix: shortest-import rule failed with .env file

### DIFF
--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -3,7 +3,7 @@
   "description": "Audit util for easy integration with auditjs",
   "license": "MIT",
   "author": "TableCheck Inc.",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "type": "module",
   "exports": {
     ".": {
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^0.6.3",
-    "@tablecheck/frontend-utils": "^2.0.0",
+    "@tablecheck/frontend-utils": "^3.0.0",
     "@turingpointde/cvss.js": "^1.4.7",
     "chalk": "^4.1.2",
     "execa": "7.1.1",

--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git@github.com:tablecheck/frontend.git"
   },
-  "version": "1.2.0",
+  "version": "2.0.0",
   "exports": {
     ".": "./index.js",
     "./formatters/junit": "./formatters/junit.js"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git@github.com:tablecheck/frontend.git"
   },
-  "version": "1.8.2",
+  "version": "2.0.0",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -28,7 +28,7 @@
     "@emotion/eslint-plugin": "^11.11.0",
     "@nx/eslint-plugin": "^16.5.0",
     "@tablecheck/eslint-plugin": "^1.2.2",
-    "@tablecheck/frontend-utils": "^2.0.0",
+    "@tablecheck/frontend-utils": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "^6.2.0",
     "@typescript-eslint/parser": "^6.2.0",
     "eslint-config-airbnb": "^19.0.4",

--- a/packages/eslint-plugin/__tests__/shortestImport.test.ts
+++ b/packages/eslint-plugin/__tests__/shortestImport.test.ts
@@ -32,7 +32,7 @@ function buildCodeCase<T extends { name?: string }>({
     importType === 'default'
       ? (importPath: string) => `import { second } from '${importPath}';`
       : (importPath: string) => `const second = import('${importPath}');`;
-  const name = `${rest.name || template(path)}: ${importType}`;
+  const name = `${rest.name || `\`${template(path)}\``} -  ${importType}`;
   if (fixedPath) {
     return {
       ...rest,

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git@github.com:tablecheck/frontend.git"
   },
-  "version": "1.2.2",
+  "version": "2.0.0",
   "exports": {
     ".": {
       "default": "./dist/index.js"
@@ -22,7 +22,7 @@
     "build": "tsc -p ./tsconfig.build.json"
   },
   "dependencies": {
-    "@tablecheck/frontend-utils": "^2.0.0",
+    "@tablecheck/frontend-utils": "^3.0.0",
     "eslint-module-utils": "2.8.0"
   },
   "peerDependencies": {

--- a/packages/eslint-plugin/src/shortestImport.ts
+++ b/packages/eslint-plugin/src/shortestImport.ts
@@ -3,11 +3,333 @@ import * as path from 'path';
 import type { TSESTree } from '@typescript-eslint/types';
 import { AST_NODE_TYPES, TSESLint } from '@typescript-eslint/utils';
 import fs from 'fs-extra';
+import { CompilerOptions } from 'typescript';
 
 type ImportExpression = TSESTree.ImportDeclaration;
 type ImportDeclaration = TSESTree.ImportExpression;
 
 export const messageId = 'shortestImport' as const;
+
+const metaCache = new Map<string, RuleChecker>();
+
+class RuleChecker {
+  private baseUrl: string | undefined;
+
+  private pathsBasePath: CompilerOptions['pathsBasePath'];
+
+  private rootDir: string | undefined;
+
+  private rootDirs: string[] | undefined;
+
+  private compilerPaths: Record<string, string>;
+
+  private pathMappings: Record<string, string>;
+
+  private aliasPathMappings: Record<string, string>;
+
+  get relativeBaseUrl(): string {
+    return path.relative(this.pathsBasePath as string, this.baseUrl ?? '');
+  }
+
+  constructor(compilerOptions: CompilerOptions) {
+    const { baseUrl, pathsBasePath, rootDir, rootDirs } = compilerOptions;
+    this.baseUrl = baseUrl;
+    this.pathsBasePath = pathsBasePath;
+    this.rootDir = rootDir;
+    this.rootDirs = rootDirs;
+    this.compilerPaths = this.composeCompilerPaths(compilerOptions.paths);
+    this.pathMappings = this.composePathMappings();
+    this.aliasPathMappings = this.composeAliasPathMappings();
+  }
+
+  private composeCompilerPaths(compilerPaths: CompilerOptions['paths']) {
+    return Object.entries(compilerPaths ?? {}).reduce(
+      (compilerPathsMap, [key, [value]]) => ({
+        ...compilerPathsMap,
+        [key.replace(/\/\*$/gi, '')]: value
+          .replace(/\/\*$/gi, '')
+          .replace(/^\.\//gi, ''),
+      }),
+      {},
+    );
+  }
+
+  private composePathMappings() {
+    return Object.fromEntries(
+      Object.entries({
+        ...this.compilerPaths,
+        ...this.composeBaseUrlPaths(),
+      } as Record<string, string>).filter(([key]) => !!key.trim()),
+    );
+  }
+
+  private composeBaseUrlPaths() {
+    if (!this.baseUrl) return {};
+    return fs
+      .readdirSync(this.baseUrl, {
+        withFileTypes: true,
+      })
+      .reduce(
+        (directoryMap, dirrent) => {
+          if (dirrent.isDirectory())
+            return {
+              ...directoryMap,
+              [dirrent.name]: path.join(this.relativeBaseUrl, dirrent.name),
+            };
+          return {
+            ...directoryMap,
+            [dirrent.name.replace(/\.[^.]+$/gi, '')]: path
+              .join(this.relativeBaseUrl, dirrent.name)
+              .replace(/^\.\//gi, ''),
+          };
+        },
+        {} as Record<string, string>,
+      );
+  }
+
+  private composeAliasPathMappings() {
+    return this.doesCompilerPathsIncludeBaseUrl()
+      ? this.compilerPaths
+      : this.pathMappings;
+  }
+
+  private doesCompilerPathsIncludeBaseUrl() {
+    return Object.values<string>(this.compilerPaths).some((value) =>
+      value.startsWith(this.relativeBaseUrl),
+    );
+  }
+
+  private getImportMeta(
+    context: Readonly<
+      TSESLint.RuleContext<
+        'shortestImport' | 'types-failed',
+        never[] | [string[]]
+      >
+    >,
+    node: ImportExpression | ImportDeclaration,
+  ):
+    | Record<string, never>
+    | Record<'importPath' | 'resolvedImportPath' | 'resolvedFilePath', string> {
+    if (node.source.type !== AST_NODE_TYPES.Literal) return {};
+    const importPath = node.source.value;
+    if (
+      typeof importPath !== 'string' ||
+      this.shouldNotChangeImport(importPath)
+    )
+      return {};
+    const filename = context.getPhysicalFilename
+      ? context.getPhysicalFilename()
+      : context.getFilename();
+    const resolvedFilePath = this.getResolvedFilePath(filename);
+    const resolvedImportPath = this.resolveImport(importPath);
+    return {
+      importPath,
+      resolvedImportPath,
+      resolvedFilePath,
+    };
+  }
+
+  public execute(
+    context: Readonly<
+      TSESLint.RuleContext<
+        'shortestImport' | 'types-failed',
+        never[] | [string[]]
+      >
+    >,
+    node: ImportExpression | ImportDeclaration,
+  ) {
+    const { importPath, resolvedImportPath, resolvedFilePath } =
+      this.getImportMeta(context, node);
+    if (!importPath) return;
+    const relativePath = this.getRelativeImport({
+      importPath,
+      resolvedImportPath,
+      resolvedFilePath,
+    });
+    const aliasPaths = this.getPathAliasImports({
+      resolvedImportPath,
+      resolvedFilePath,
+    });
+    const preferredPath = this.getPreferredPath({
+      resolvedFilePath,
+      relativePath,
+      aliasPaths,
+      avoidRelativeParents: context.options[0] || [],
+    });
+
+    if (preferredPath === importPath) return;
+
+    context.report({
+      node,
+      messageId,
+      data: {
+        preferredPath,
+        importPath,
+      },
+      fix(fixer) {
+        return fixer.replaceText(node.source, `'${preferredPath}'`);
+      },
+    });
+  }
+
+  private shouldNotChangeImport(importPath: string) {
+    if (importPath.startsWith('@') || importPath === '.') return true;
+    const isPathMapping = Object.keys(this.pathMappings).some((key) =>
+      importPath.startsWith(key),
+    );
+    if (isPathMapping) return false;
+    return !importPath.startsWith('.') && !importPath.startsWith('/');
+  }
+
+  private resolveImport(importPath: string) {
+    const importParts = importPath.split('/');
+    if (this.pathMappings[importParts[0]]) {
+      return [this.pathMappings[importParts[0]]]
+        .concat(importParts.slice(1))
+        .join('/');
+    }
+    return importParts.join('/');
+  }
+
+  private getRelativeImport({
+    importPath,
+    resolvedImportPath,
+    resolvedFilePath,
+  }: {
+    importPath: string;
+    resolvedImportPath: string;
+    resolvedFilePath: string;
+  }) {
+    if (importPath.startsWith('.')) return importPath;
+    const relativePath = path.relative(
+      path.dirname(resolvedFilePath),
+      resolvedImportPath,
+    );
+    if (relativePath.startsWith('.')) return relativePath;
+    return `./${relativePath}`;
+  }
+
+  private getPathAliasImports({
+    resolvedImportPath: importPath,
+    resolvedFilePath,
+  }: {
+    resolvedImportPath: string;
+    resolvedFilePath: string;
+  }) {
+    let resolvedImportPath = importPath;
+    if (importPath.startsWith('.')) {
+      resolvedImportPath = path.resolve(
+        path.dirname(resolvedFilePath),
+        importPath,
+      );
+    }
+    const matchedMappings = Object.entries(this.aliasPathMappings).filter(
+      ([, value]) => resolvedImportPath.includes(value),
+    );
+    return matchedMappings.map(([key, value]) =>
+      resolvedImportPath.replace(
+        new RegExp(`^.*?${value.replace(/\//gi, '\\/')}`),
+        key,
+      ),
+    );
+  }
+
+  private getPreferredPath({
+    resolvedFilePath,
+    relativePath,
+    aliasPaths,
+    avoidRelativeParents,
+  }: {
+    resolvedFilePath: string;
+    relativePath: string;
+    aliasPaths: string[];
+    avoidRelativeParents: string[];
+  }) {
+    if (!aliasPaths.length) return relativePath;
+    const parentSlugs = relativePath.split('/').filter((s) => s === '..');
+    const shouldAvoidRelative =
+      this.relativeGoesThroughBaseUrl(relativePath, resolvedFilePath) ||
+      aliasPaths.some((aliasPath) => {
+        if (!avoidRelativeParents.length) return false;
+        const relativeRoot = aliasPath
+          .split('/')
+          .slice(0, -1 * parentSlugs.length)
+          .join('/');
+        return avoidRelativeParents.includes(relativeRoot);
+      });
+    const aliasWithLength = aliasPaths
+      .map((aliasPath) => ({
+        aliasPath,
+        length: aliasPath.split('/').length,
+      }))
+      .concat(
+        shouldAvoidRelative
+          ? []
+          : [
+              {
+                aliasPath: relativePath,
+                length: relativePath.split('/').length,
+              },
+            ],
+      )
+      .sort((a, b) => a.length - b.length);
+    return aliasWithLength[0]?.aliasPath;
+  }
+
+  private relativeGoesThroughBaseUrl(
+    relativePath: string,
+    resolvedFilePath: string,
+  ) {
+    const parentPath = relativePath
+      .split('/')
+      .filter((part) => part === '..')
+      .join('/');
+    const absoluteImportPath = path.resolve(
+      path.dirname(resolvedFilePath),
+      relativePath,
+    );
+    const resolvedPathRoot = path.resolve(
+      path.dirname(resolvedFilePath),
+      parentPath,
+    );
+    return resolvedPathRoot === absoluteImportPath;
+  }
+
+  private getResolvedFilePath(filename: string) {
+    if (!filename.startsWith('/')) {
+      const resolvedPaths = [
+        this.pathsBasePath,
+        this.rootDir,
+        ...(this.rootDirs ?? []),
+      ].map((potentialRoot) => {
+        if (typeof potentialRoot !== 'string') return undefined;
+        return [potentialRoot, path.resolve(potentialRoot, filename)];
+      });
+      const match = resolvedPaths.find((tuple) => {
+        if (!tuple) return false;
+        const [, resolvedPath] = tuple;
+        return fs.existsSync(resolvedPath);
+      });
+      return match ? path.relative(match[0], match[1]) : filename;
+    }
+
+    // this is because sometimes `baseUrl` is lowercase (eg `/users/someone/...`)
+    // and then filename is uppercase (eg `/Users/someone/...`)
+    // so we need to normalise them so `path.relative` works correctly
+    const pattern = `${this.baseUrl}/`
+      .replace(/\/+/gi, '/')
+      .replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+    return filename.replace(new RegExp(pattern, 'ig'), '');
+  }
+}
+
+function getRuleChecker(compilerOptions: CompilerOptions): RuleChecker {
+  const cacheKey = JSON.stringify(compilerOptions.configFilePath);
+  if (!metaCache.has(cacheKey)) {
+    metaCache.set(cacheKey, new RuleChecker(compilerOptions));
+  }
+  return metaCache.get(cacheKey)!;
+}
 
 export const shortestImport: TSESLint.RuleModule<
   typeof messageId | 'types-failed',
@@ -33,7 +355,6 @@ export const shortestImport: TSESLint.RuleModule<
   },
   defaultOptions: [],
   create(context) {
-    const avoidRelativeParents = context.options[0] || [];
     const compilerOptions = context
       .getSourceCode()
       .parserServices.program?.getCompilerOptions();
@@ -47,206 +368,14 @@ export const shortestImport: TSESLint.RuleModule<
         },
       };
     }
-    const { baseUrl, pathsBasePath, rootDir, rootDirs } = compilerOptions;
-
-    function getResolvedFilePath() {
-      const filename = context.getPhysicalFilename
-        ? context.getPhysicalFilename()
-        : context.getFilename();
-      if (!filename.startsWith('/')) {
-        const resolvedPaths = [pathsBasePath, rootDir, ...(rootDirs ?? [])].map(
-          (potentialRoot) => {
-            if (typeof potentialRoot !== 'string') return undefined;
-            return [potentialRoot, path.resolve(potentialRoot, filename)];
-          },
-        );
-        const match = resolvedPaths.find((tuple) => {
-          if (!tuple) return false;
-          const [, resolvedPath] = tuple;
-          return fs.existsSync(resolvedPath);
-        });
-        return match ? path.relative(match[0], match[1]) : filename;
-      }
-
-      // this is because sometimes `baseUrl` is lowercase (eg `/users/someone/...`)
-      // and then filename is uppercase (eg `/Users/someone/...`)
-      // so we need to normalise them so `path.relative` works correctly
-      const pattern = `${baseUrl}/`
-        .replace(/\/+/gi, '/')
-        .replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
-      return filename.replace(new RegExp(pattern, 'ig'), '');
-    }
-
-    const resolvedFilePath = getResolvedFilePath();
-    const relativeBaseUrl = path.relative(
-      pathsBasePath as string,
-      baseUrl ?? '',
-    );
-    const baseUrlPaths = baseUrl
-      ? fs
-          .readdirSync(baseUrl, {
-            withFileTypes: true,
-          })
-          .reduce(
-            (directoryMap, dirrent) => {
-              if (dirrent.isDirectory())
-                return {
-                  ...directoryMap,
-                  [dirrent.name]: path.join(relativeBaseUrl, dirrent.name),
-                };
-              return {
-                ...directoryMap,
-                [dirrent.name.replace(/\.[^.]+$/gi, '')]: path
-                  .join(relativeBaseUrl, dirrent.name)
-                  .replace(/^\.\//gi, ''),
-              };
-            },
-            {} as Record<string, string>,
-          )
-      : {};
-    const compilerPaths = Object.entries(compilerOptions.paths ?? {}).reduce(
-      (compilerPathsMap, [key, [value]]) => ({
-        ...compilerPathsMap,
-        [key.replace(/\/\*$/gi, '')]: value
-          .replace(/\/\*$/gi, '')
-          .replace(/^\.\//gi, ''),
-      }),
-      {},
-    );
-
-    const doesCompilerPathsIncludeBaseUrl = Object.values<string>(
-      compilerPaths,
-    ).some((value) => value.startsWith(relativeBaseUrl));
-
-    const pathMappings: Record<string, string> = {
-      ...compilerPaths,
-      ...baseUrlPaths,
-    };
-    const aliasPathMappings: Record<string, string> =
-      doesCompilerPathsIncludeBaseUrl ? compilerPaths : pathMappings;
-    function resolveImport(importPath: string) {
-      const importParts = importPath.split('/');
-      if (pathMappings[importParts[0]]) {
-        return [pathMappings[importParts[0]]]
-          .concat(importParts.slice(1))
-          .join('/');
-      }
-      return importParts.join('/');
-    }
-    function getPathAliasImports(importPath: string) {
-      let resolvedImportPath = importPath;
-      if (importPath.startsWith('.')) {
-        resolvedImportPath = path.resolve(
-          path.dirname(resolvedFilePath),
-          importPath,
-        );
-      }
-      const matchedMappings = Object.entries(aliasPathMappings).filter(
-        ([, value]) => resolvedImportPath.includes(value),
-      );
-      return matchedMappings.map(([key, value]) =>
-        resolvedImportPath.replace(
-          new RegExp(`^.*?${value.replace(/\//gi, '\\/')}`),
-          key,
-        ),
-      );
-    }
-    function getRelativeImport(importPath: string, resolvedImportPath: string) {
-      if (importPath.startsWith('.')) return importPath;
-      const relativePath = path.relative(
-        path.dirname(resolvedFilePath),
-        resolvedImportPath,
-      );
-      if (relativePath.startsWith('.')) return relativePath;
-      return `./${relativePath}`;
-    }
-    function relativeGoesThroughBaseUrl(relativePath: string) {
-      const parentPath = relativePath
-        .split('/')
-        .filter((part) => part === '..')
-        .join('/');
-      const absoluteImportPath = path.resolve(
-        path.dirname(resolvedFilePath),
-        relativePath,
-      );
-      const resolvedPathRoot = path.resolve(
-        path.dirname(resolvedFilePath),
-        parentPath,
-      );
-      return resolvedPathRoot === absoluteImportPath;
-    }
-    function getPreferredPath(relativePath: string, aliasPaths: string[]) {
-      if (!aliasPaths.length) return relativePath;
-      const parentSlugs = relativePath.split('/').filter((s) => s === '..');
-      const shouldAvoidRelative =
-        relativeGoesThroughBaseUrl(relativePath) ||
-        aliasPaths.some((aliasPath) => {
-          if (!avoidRelativeParents.length) return false;
-          const relativeRoot = aliasPath
-            .split('/')
-            .slice(0, -1 * parentSlugs.length)
-            .join('/');
-          return avoidRelativeParents.includes(relativeRoot);
-        });
-      const aliasWithLength = aliasPaths
-        .map((aliasPath) => ({
-          aliasPath,
-          length: aliasPath.split('/').length,
-        }))
-        .concat(
-          shouldAvoidRelative
-            ? []
-            : [
-                {
-                  aliasPath: relativePath,
-                  length: relativePath.split('/').length,
-                },
-              ],
-        )
-        .sort((a, b) => a.length - b.length);
-      return aliasWithLength[0]?.aliasPath;
-    }
-
-    function shouldNotChangeImport(importPath: string) {
-      if (importPath.startsWith('@') || importPath === '.') return true;
-      const isPathMapping = Object.keys(pathMappings).some((key) =>
-        importPath.startsWith(key),
-      );
-      if (isPathMapping) return false;
-      return !importPath.startsWith('.') && !importPath.startsWith('/');
-    }
-
-    function checkAndFixImport(node: ImportExpression | ImportDeclaration) {
-      if (node.source.type !== AST_NODE_TYPES.Literal) return;
-      const importPath = node.source.value;
-      if (typeof importPath !== 'string' || shouldNotChangeImport(importPath))
-        return;
-      const resolvedImport = resolveImport(importPath);
-      const relativePath = getRelativeImport(importPath, resolvedImport);
-      const aliasPaths = getPathAliasImports(resolvedImport);
-      const preferredPath = getPreferredPath(relativePath, aliasPaths);
-
-      if (preferredPath === importPath) return;
-
-      context.report({
-        node,
-        messageId,
-        data: {
-          preferredPath,
-          importPath,
-        },
-        fix(fixer) {
-          return fixer.replaceText(node.source, `'${preferredPath}'`);
-        },
-      });
-    }
+    const checker = getRuleChecker(compilerOptions);
 
     return {
       ImportDeclaration(node) {
-        checkAndFixImport(node);
+        checker.execute(context, node);
       },
       ImportExpression(node) {
-        checkAndFixImport(node);
+        checker.execute(context, node);
       },
     };
   },

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -35,7 +35,7 @@
     "tsimportlib": "0.0.5"
   },
   "peerDependencies": {
-    "@tablecheck/eslint-config": "^1.8.2"
+    "@tablecheck/eslint-config": ">=1.8.2"
   },
   "devDependencies": {
     "@types/flat": "5.0.2",

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tablecheck/nx",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "type": "commonjs",
   "exports": {
     ".": {
@@ -25,7 +25,7 @@
   "dependencies": {
     "@nx/devkit": "^16",
     "@nx/linter": "^16",
-    "@tablecheck/frontend-utils": "^2.0.0",
+    "@tablecheck/frontend-utils": "^3.0.0",
     "chalk": "^4.1.2",
     "flat": "5.0.2",
     "fs-extra": "11.1.1",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git@github.com:tablecheck/frontend.git"
   },
-  "version": "1.0.0",
+  "version": "2.0.0",
   "main": "./config.json",
   "peerDependencies": {
     "prettier": "^3"

--- a/packages/semantic-release-config/package.json
+++ b/packages/semantic-release-config/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git@github.com:tablecheck/frontend.git"
   },
-  "version": "2.5.0",
+  "version": "3.0.0",
   "main": "index.js",
   "files": [
     "with-npm-publish/package.json",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -3,7 +3,7 @@
   "description": "Generic utils shared inside @tablecheck packages",
   "license": "MIT",
   "author": "TableCheck Inc.",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "type": "commonjs",
   "exports": {
     ".": {


### PR DESCRIPTION
The issue was caused by a `.env` file at the tsconfig root which resolved to a `{ '': '...' }` in the alias mappings which matched _everything_.

Had troubling navigating around so cleaned up the code as well, this mainly affected `import ... from 'axios'` or similar npm level imports.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/frontend-audit@2.0.1-canary.88.6467591840.0
  npm install @tablecheck/commitlint-config@2.0.1-canary.88.6467591840.0
  npm install @tablecheck/eslint-config@2.0.1-canary.88.6467591840.0
  npm install @tablecheck/eslint-plugin@2.0.1-canary.88.6467591840.0
  npm install @tablecheck/nx@2.0.1-canary.88.6467591840.0
  npm install @tablecheck/prettier-config@2.0.1-canary.88.6467591840.0
  npm install @tablecheck/semantic-release-config@3.0.1-canary.88.6467591840.0
  npm install @tablecheck/frontend-utils@3.0.1-canary.88.6467591840.0
  # or 
  yarn add @tablecheck/frontend-audit@2.0.1-canary.88.6467591840.0
  yarn add @tablecheck/commitlint-config@2.0.1-canary.88.6467591840.0
  yarn add @tablecheck/eslint-config@2.0.1-canary.88.6467591840.0
  yarn add @tablecheck/eslint-plugin@2.0.1-canary.88.6467591840.0
  yarn add @tablecheck/nx@2.0.1-canary.88.6467591840.0
  yarn add @tablecheck/prettier-config@2.0.1-canary.88.6467591840.0
  yarn add @tablecheck/semantic-release-config@3.0.1-canary.88.6467591840.0
  yarn add @tablecheck/frontend-utils@3.0.1-canary.88.6467591840.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
