### PR TITLE
fix: audit should exit based on success

### DIFF
--- a/auditjs.json
+++ b/auditjs.json
@@ -1244,6 +1244,22 @@
           "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2022-25883?component-type=npm&component-name=semver&utm_source=auditjs&utm_medium=integration&utm_content=4.0.39"
         }
       ]
+    },
+    {
+      "coordinates": "pkg:npm/postcss@7.0.39",
+      "description": "Tool for transforming styles with JS plugins",
+      "reference": "https://ossindex.sonatype.org/component/pkg:npm/postcss@7.0.39?utm_source=auditjs&utm_medium=integration&utm_content=4.0.41",
+      "vulnerabilities": [
+        {
+          "id": "CVE-2023-44270",
+          "title": "[CVE-2023-44270] CWE-74: Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')",
+          "description": "An issue was discovered in PostCSS before 8.4.31. The vulnerability affects linters using PostCSS to parse external untrusted CSS. An attacker can prepare CSS in such a way that it will contains parts parsed by PostCSS as a CSS comment. After processing by PostCSS, it will be included in the PostCSS output in CSS nodes (rules, properties) despite being included in a comment.",
+          "cvssScore": 5.3,
+          "cvssVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+          "cve": "CVE-2023-44270",
+          "reference": "https://ossindex.sonatype.org/vulnerability/CVE-2023-44270?component-type=npm&component-name=postcss&utm_source=auditjs&utm_medium=integration&utm_content=4.0.41"
+        }
+      ]
     }
   ],
   "ignore": [
@@ -1468,6 +1484,9 @@
     },
     {
       "id": "CVE-2022-25883"
+    },
+    {
+      "id": "CVE-2023-44270"
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@swc/cli": "~0.1.62",
         "@swc/core": "~1.3.91",
         "@tablecheck/eslint-config": "file:packages/eslint-config",
+        "@tablecheck/eslint-plugin": "file:packages/eslint-plugin",
         "@tablecheck/prettier-config": "file:packages/prettier-config",
         "@types/fs-extra": "^11.0.2",
         "@types/node": "20.8.0",
@@ -2439,9 +2440,9 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.0.tgz",
-      "integrity": "sha512-t/QaEvyIoIkwzpiZ7aoSKK8kObQYeF7T2v+dazAYCb8SXtp58zEVkWW7zAnju8FNKNdr4ScAOEDmMItbyOmEYw==",
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
         "@babel/generator": "^7.23.0",
@@ -2507,6 +2508,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9067,6 +9069,118 @@
     "node_modules/@tablecheck/frontend-audit": {
       "resolved": "packages/audit",
       "link": true
+    },
+    "node_modules/@tablecheck/frontend-utils": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@tablecheck/frontend-utils/-/frontend-utils-5.0.0.tgz",
+      "integrity": "sha512-bo8I4lEZVXSwWUUe/q4Dt2M8C3K6Rh+oHO4AJLh1hKs7hchDTBJ/vu9M79WshCWO60UJHxsnjI59P4A0SArHQQ==",
+      "dependencies": {
+        "@nx/devkit": "^16",
+        "cosmiconfig": "^8.2.0",
+        "fs-extra": "^11.1.1",
+        "glob": "^10.3.3",
+        "jiti": "^1.19.1",
+        "minimist": "^1.2.8",
+        "prettier": "^3.0.0",
+        "prettier-package-json": "2.8.0"
+      },
+      "engines": {
+        "node": ">= 16.16.0"
+      }
+    },
+    "node_modules/@tablecheck/frontend-utils/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@tablecheck/frontend-utils/node_modules/cosmiconfig": {
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+      "dependencies": {
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0",
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tablecheck/frontend-utils/node_modules/foreground-child": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@tablecheck/frontend-utils/node_modules/glob": {
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.5",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@tablecheck/frontend-utils/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@tablecheck/frontend-utils/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/@tablecheck/nx": {
       "resolved": "packages/nx",
@@ -22402,6 +22516,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.20.0.tgz",
+      "integrity": "sha512-3TV69ZbrvV6U5DfQimop50jE9Dl6J8O1ja1dvBbMba/sZ3YBEQqJ2VZRoQPVnhlzjNtU1vaXRZVrVjU4qtm8yA==",
+      "bin": {
+        "jiti": "bin/jiti.js"
       }
     },
     "node_modules/js-string-escape": {
@@ -36858,6 +36980,18 @@
       "peerDependencies": {
         "eslint": "^8",
         "typescript": "5.x"
+      }
+    },
+    "packages/eslint-config/node_modules/@tablecheck/eslint-plugin": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@tablecheck/eslint-plugin/-/eslint-plugin-4.0.0.tgz",
+      "integrity": "sha512-MPKh+PgglQU6BSnC2xiVpbTheaadYVpeeXJy7fmGM1UqHzyfKoSZXkf/43iWOnHTQfsQW7Zj5DZ+bVpH3cXHvw==",
+      "dependencies": {
+        "@tablecheck/frontend-utils": "^5.0.0",
+        "eslint-module-utils": "2.8.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8"
       }
     },
     "packages/eslint-config/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@swc/cli": "~0.1.62",
     "@swc/core": "~1.3.91",
     "@tablecheck/eslint-config": "file:packages/eslint-config",
+    "@tablecheck/eslint-plugin": "file:packages/eslint-plugin",
     "@tablecheck/prettier-config": "file:packages/prettier-config",
     "@types/fs-extra": "^11.0.2",
     "@types/node": "20.8.0",

--- a/packages/audit/src/index.ts
+++ b/packages/audit/src/index.ts
@@ -256,7 +256,9 @@ ${this.getVectorMetrics(vector)
     }
 
     getDependencyVersion() {
-      return this.dep.coordinates.substring(8) as `${string}@${string}`;
+      return this.dep.coordinates
+        .substring(8)
+        .replace(/%40/g, '@') as `${string}@${string}`;
     }
 
     async loadNpmPackages(dependencyVersion: string) {
@@ -343,7 +345,7 @@ ${this.getVectorMetrics(vector)
             acc.push(s);
             return acc;
           }, [] as string[])
-          .map((s) => `${s.split('@')[0]}@latest`)
+          .map((s) => s.split('@').slice(0, -1).join('@'))
           .join(' ')}\``,
       )}\n`
     : '';
@@ -383,6 +385,11 @@ export async function run({
     preferLocal: true,
     reject: false,
   });
+  if (ciResult.failed) {
+    console.log(chalk.red.bold('\u2718 Audit failed'));
+  } else {
+    console.log(chalk.green.bold('\u2714 Audit passed'));
+  }
   const junitFilePath = path.join(rootPath, 'junit', 'auditjs.xml');
   fs.outputFileSync(junitFilePath, ciResult.stdout);
   console.log(chalk.blue.bold(`Report written to ${junitFilePath}`));

--- a/packages/audit/src/main.ts
+++ b/packages/audit/src/main.ts
@@ -11,8 +11,8 @@ const argv = minimist(process.argv.slice(2), {
 });
 
 run({ rootPath: process.cwd(), updatePrompts: !argv.ci })
-  .then(() => {
-    process.exit(0);
+  .then((didPass) => {
+    process.exit(didPass ? 0 : 1);
   })
   .catch((err) => {
     console.error(err);


### PR DESCRIPTION
No ticket
![CleanShot 2023-10-13 at 12 10 14](https://github.com/tablecheck/tablecheck-react-system/assets/1085899/343ef983-aac5-49e4-b7f0-15e340faeeaa)

![CleanShot 2023-10-13 at 12 02 06](https://github.com/tablecheck/tablecheck-react-system/assets/1085899/9d22ad0c-dc6b-4821-b7d1-d4b3ca8ac32a)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/frontend-audit@5.0.1-canary.90.6503547560.0
  # or 
  yarn add @tablecheck/frontend-audit@5.0.1-canary.90.6503547560.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
