### PR TITLE
feat: add react-refresh eslint rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2508,6 +2508,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -17446,6 +17447,14 @@
       },
       "peerDependencies": {
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/eslint-plugin-react-refresh": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.3.tgz",
+      "integrity": "sha512-Hh0wv8bUNY877+sI0BlCUlsS0TYYQqvzEwJsJJPM2WF4RnTStSnSR3zdJYa2nPOJgg3UghXi54lVyMSmpCalzA==",
+      "peerDependencies": {
+        "eslint": ">=7"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {
@@ -36965,6 +36974,7 @@
         "eslint-plugin-promise": "^6.1.1",
         "eslint-plugin-react": "^7.33.0",
         "eslint-plugin-react-hooks": "^4.6.0",
+        "eslint-plugin-react-refresh": "^0.4.3",
         "fs-extra": "^11.1.1",
         "queue-microtask": "^1.2.3"
       },

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -43,6 +43,7 @@
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-react": "^7.33.0",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.4.3",
     "fs-extra": "^11.1.1",
     "queue-microtask": "^1.2.3"
   },

--- a/packages/eslint-config/src/index.ts
+++ b/packages/eslint-config/src/index.ts
@@ -54,6 +54,7 @@ module.exports = {
     'cypress',
     '@tablecheck',
     '@nx',
+    'react-refresh',
   ],
 
   globals: {

--- a/packages/eslint-config/src/rules/react.ts
+++ b/packages/eslint-config/src/rules/react.ts
@@ -54,4 +54,8 @@ export const reactRules: Linter.RulesRecord = {
   'react/jsx-fragments': 'error',
   'react/jsx-no-useless-fragment': ['error', { allowExpressions: true }],
   '@tablecheck/consistent-react-import': 'error',
+  'react-refresh/only-export-components': [
+    'error',
+    { allowConstantExport: true },
+  ],
 };


### PR DESCRIPTION
As we use Vite by default, this eslint rule will help with development and also keeping files consistent. The options to avoid this rule erroring are;
* Put all styled components/types/utils etc in the same file
* Put them in other `.style.ts` or `.types.ts` or basically a different file.

Trying this at a really strict level to start out and will downgrade to warn if it reports too many false positives.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/eslint-config@8.1.0-canary.91.6527621571.0
  # or 
  yarn add @tablecheck/eslint-config@8.1.0-canary.91.6527621571.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
